### PR TITLE
Harden backend auth configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# ── Backend (Python / Flask) ───────────────────────────────────
+backend/.env
+backend/instance/
+__pycache__/
+*.pyc
+*.pyo
+.expo/
+
+# ── Frontend (Node / Expo) ────────────────────────────────────
+node_modules/
+
+# ── IDE / OS ──────────────────────────────────────────────────
+.DS_Store
+Thumbs.db
+*.swp
+*.swo

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,7 @@
+# backend/.env.example
+# Copy this file to .env and set your own values.
+# DO NOT commit .env — it should be in .gitignore.
+
+# Generate a strong random key:
+#   python -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=your-secret-key-here

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,5 @@
 from flask import Flask
+from flask_cors import CORS
 from .models import db
 from .extensions import ma
 from .blueprints.auth_users import auth_users_bp
@@ -11,7 +12,9 @@ def create_app(config_name):
 
     app = Flask(__name__)
     app.config.from_object(f'config.{config_name}')
-    
+
+    CORS(app)
+
     db.init_app(app)
     ma.init_app(app)
 

--- a/backend/app/blueprints/auth_users/routes.py
+++ b/backend/app/blueprints/auth_users/routes.py
@@ -25,7 +25,10 @@ def login():
             'user': auth_user_schema.dump(user)
         }), 200
     
-    return jsonify({'error': 'invalid username or password'}), 401
+    return jsonify({
+        'error': 'Invalid username or password.',
+        'code':  'INVALID_CREDENTIALS',
+    }), 401
 
 
 # Register/Create Users - for testing

--- a/backend/app/util/auth.py
+++ b/backend/app/util/auth.py
@@ -3,9 +3,17 @@ import jose
 from datetime import datetime, timedelta, timezone
 from functools import wraps
 from flask import request, jsonify
+import os
 
 
-SECRET_KEY = "temp key"  # In production, change into secure key/storage
+# Loaded from the SECRET_KEY environment variable (set in backend/.env).
+SECRET_KEY = os.environ.get('SECRET_KEY')
+if not SECRET_KEY:
+    raise RuntimeError(
+        "SECRET_KEY environment variable is not set. "
+        "Copy backend/.env.example to backend/.env and set a strong random value."
+    )
+assert isinstance(SECRET_KEY, str)
 
 def encode_token(user_id, role):
     payload = {

--- a/backend/flask_app.py
+++ b/backend/flask_app.py
@@ -1,3 +1,6 @@
+from dotenv import load_dotenv
+load_dotenv()  # loads backend/.env into os.environ before anything else imports
+
 from app import create_app
 from app.models import db
 
@@ -7,4 +10,5 @@ with app.app_context():
     # db.drop_all()
     db.create_all()
 
-app.run()
+if __name__ == '__main__':
+    app.run(host='0.0.0.0')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,3 +18,5 @@ six==1.17.0
 SQLAlchemy==2.0.48
 typing_extensions==4.15.0
 Werkzeug==3.1.6
+python-dotenv==1.0.1
+Flask-Cors==5.0.1

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,76 @@
+import os
+import pytest
+
+os.environ.setdefault('SECRET_KEY', 'test-secret-key-for-pytest')
+
+from app import create_app
+from app.models import db as _db, Auth_users, Contractors
+from werkzeug.security import generate_password_hash
+from datetime import date
+
+
+@pytest.fixture(scope='session')
+def app():
+    app = create_app('TestingConfig')
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['TESTING'] = True
+    return app
+
+
+@pytest.fixture(autouse=True)
+def db(app):
+    with app.app_context():
+        _db.create_all()
+        yield _db
+        _db.session.rollback()
+        _db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def seed_user(db):
+    user = Auth_users(
+        username='testuser',
+        email='test@test.com',
+        password=generate_password_hash('123456'),
+        role='contractor',
+        created_by=1,
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+@pytest.fixture
+def seed_contractor(db, seed_user):
+    contractor = Contractors(
+        id=seed_user.id,
+        vendor_id=1,
+        manager_id=1,
+        first_name='Test',
+        last_name='User',
+        license_number='TEST001',
+        expiration_date=date(2027, 1, 1),
+        contractor_type='general',
+        status='active',
+        tax_classification='W9',
+        contact_number='555-555-5555',
+        date_of_birth=date(1990, 1, 1),
+        address='123 Test St',
+    )
+    db.session.add(contractor)
+    db.session.commit()
+    return contractor
+
+
+@pytest.fixture
+def auth_token(client, seed_user):
+    resp = client.post('/auth/login', json={
+        'username': 'testuser',
+        'password': '123456',
+    })
+    return resp.get_json()['token']

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,129 @@
+class TestLogin:
+
+    def test_login_success(self, client, seed_user):
+        resp = client.post('/auth/login', json={
+            'username': 'testuser',
+            'password': '123456',
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert 'token' in data
+        assert data['message'] == 'Successfully Logged in'
+        assert data['user']['username'] == 'testuser'
+
+    def test_login_wrong_password(self, client, seed_user):
+        resp = client.post('/auth/login', json={
+            'username': 'testuser',
+            'password': 'wrongpassword',
+        })
+        assert resp.status_code == 401
+        data = resp.get_json()
+        assert data['code'] == 'INVALID_CREDENTIALS'
+
+    def test_login_nonexistent_user(self, client):
+        resp = client.post('/auth/login', json={
+            'username': 'nobody',
+            'password': '123456',
+        })
+        assert resp.status_code == 401
+
+    def test_login_missing_username(self, client):
+        resp = client.post('/auth/login', json={
+            'password': '123456',
+        })
+        assert resp.status_code == 400
+
+    def test_login_missing_password(self, client):
+        resp = client.post('/auth/login', json={
+            'username': 'testuser',
+        })
+        assert resp.status_code == 400
+
+    def test_login_token_is_valid_jwt(self, client, seed_user):
+        resp = client.post('/auth/login', json={
+            'username': 'testuser',
+            'password': '123456',
+        })
+        token = resp.get_json()['token']
+        assert len(token.split('.')) == 3
+
+
+class TestCreateUser:
+
+    def test_create_user_success(self, client):
+        resp = client.post('/auth', json={
+            'username': 'newuser',
+            'email': 'new@test.com',
+            'password': 'securepass',
+            'role': 'contractor',
+            'created_by': 1,
+        })
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data['username'] == 'newuser'
+
+    def test_create_duplicate_user(self, client, seed_user):
+        resp = client.post('/auth', json={
+            'username': 'testuser',
+            'email': 'other@test.com',
+            'password': '123456',
+            'role': 'contractor',
+            'created_by': 1,
+        })
+        assert resp.status_code == 400
+
+
+class TestOfflinePin:
+
+    def test_set_pin_success(self, client, seed_contractor, auth_token):
+        resp = client.post('/auth/offline-pin',
+            json={'pin': '123456'},
+            headers={'Authorization': f'Bearer {auth_token}'},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()['message'] == 'offline pin set'
+
+    def test_set_pin_too_short(self, client, seed_contractor, auth_token):
+        resp = client.post('/auth/offline-pin',
+            json={'pin': '123'},
+            headers={'Authorization': f'Bearer {auth_token}'},
+        )
+        assert resp.status_code == 400
+
+    def test_set_pin_no_token(self, client):
+        resp = client.post('/auth/offline-pin',
+            json={'pin': '123456'},
+        )
+        assert resp.status_code == 401
+
+    def test_set_pin_no_contractor_record(self, client, seed_user, auth_token):
+        resp = client.post('/auth/offline-pin',
+            json={'pin': '123456'},
+            headers={'Authorization': f'Bearer {auth_token}'},
+        )
+        assert resp.status_code == 404
+
+
+class TestTokenProtection:
+
+    def test_missing_token_returns_401(self, client):
+        resp = client.get('/contractors/profile')
+        assert resp.status_code == 401
+
+    def test_expired_token_returns_403(self, client):
+        from app.util.auth import SECRET_KEY
+        from jose import jwt
+        from datetime import datetime, timedelta, timezone
+
+        expired_payload = {
+            'exp': datetime.now(timezone.utc) - timedelta(hours=1),
+            'iat': datetime.now(timezone.utc) - timedelta(hours=2),
+            'sub': '1',
+            'role': 'contractor',
+        }
+        expired_token = jwt.encode(expired_payload, SECRET_KEY, algorithm='HS256')
+
+        resp = client.get('/contractors/profile',
+            headers={'Authorization': f'Bearer {expired_token}'},
+        )
+        assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- Move SECRET_KEY from hardcoded value to environment variable
- Add Flask-CORS for cross-origin frontend requests
- Standardize login error response with error code
- Add .env.example template for developer setup
- Add pytest test suite for auth endpoints
- Guard flask_app.py with __name__ == '__main__' and load dotenv

## Test plan
- Run `pytest backend/tests/` — all tests should pass
- Verify .env with SECRET_KEY is required to start the server
- Test login endpoint returns `INVALID_CREDENTIALS` code on 401

Relates to #139 