### PR TITLE
 Wire frontend login UI to backend auth API

### DIFF
--- a/frontend/field-force-contractor/App.tsx
+++ b/frontend/field-force-contractor/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { LoadFonts } from "./utils/LoadFonts";
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { AuthProvider } from './contexts/AuthContext';
 import {Blank} from "./screens/Blank";
 import HomeScreen from "./screens/HomeScreen"
 import {screenConfig} from "./constants/ScreenConfig";
@@ -46,15 +47,16 @@ export default function App() {
   }, []);
  
   return (
-   (externalFontsLoaded) && 
+   (externalFontsLoaded) &&
+  <AuthProvider>
   <NavigationContainer>
 
     <StackNavigator.Navigator screenOptions={screenConfig.window} initialRouteName="SplashScreen">
-      
+
       <StackNavigator.Screen name="SplashScreen"  component={SplashScreen}/>
       <StackNavigator.Screen name="Blank" component={Blank}/>
       <StackNavigator.Screen name="Home" component={HomeScreen}/>
-      
+
       <StackNavigator.Screen name="Login"           component={LoginScreen}           />
       <StackNavigator.Screen name="OfflineLogin"    component={OfflineLoginScreen}    />
       <StackNavigator.Screen name="BiometricCheck"  component={BiometricScreen}       />
@@ -67,5 +69,6 @@ export default function App() {
     </StackNavigator.Navigator>
 
   </NavigationContainer>
+  </AuthProvider>
   );
 }

--- a/frontend/field-force-contractor/contexts/AuthContext.tsx
+++ b/frontend/field-force-contractor/contexts/AuthContext.tsx
@@ -1,0 +1,116 @@
+// AuthContext.tsx
+// Provides app-wide auth state: token, user info, login/logout helpers.
+// On mount checks expo-secure-store for a stored JWT and validates expiry.
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  ReactNode,
+} from 'react';
+import { getToken, saveToken, deleteToken } from '../utils/secureStorage';
+import type { UserInfo } from '../utils/api';
+
+// ── Types ──────────────────────────────────────────────────────
+
+interface AuthContextType {
+  token:           string | null;
+  user:            UserInfo | null;
+  isAuthenticated: boolean;
+  isLoading:       boolean;
+  login:           (token: string, user: UserInfo) => Promise<void>;
+  logout:          () => Promise<void>;
+}
+
+// ── JWT decode helper ──────────────────────────────────────────
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const base64Url = token.split('.')[1];
+    if (!base64Url) return null;
+    const base64  = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const padded  = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+    const decoded = atob(padded);
+    return JSON.parse(decoded) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function isTokenExpired(token: string): boolean {
+  const payload = decodeJwtPayload(token);
+  if (!payload || typeof payload.exp !== 'number') return true;
+  return Date.now() / 1000 > payload.exp;
+}
+
+// ── Context setup ──────────────────────────────────────────────
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [token,     setToken]     = useState<string | null>(null);
+  const [user,      setUser]      = useState<UserInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const restoreSession = async () => {
+      try {
+        const stored = await getToken();
+
+        if (stored && !isTokenExpired(stored)) {
+          const payload = decodeJwtPayload(stored);
+          setToken(stored);
+          setUser({
+            id:       payload ? Number(payload.sub) : 0,
+            username: '',
+            role:     payload ? String(payload.role ?? '') : '',
+          });
+        } else if (stored) {
+          await deleteToken();
+        }
+      } catch {
+        // SecureStore read failure
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    restoreSession();
+  }, []);
+
+  const login = async (newToken: string, userInfo: UserInfo) => {
+    await saveToken(newToken);
+    setToken(newToken);
+    setUser(userInfo);
+  };
+
+  const logout = async () => {
+    await deleteToken();
+    setToken(null);
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{
+        token,
+        user,
+        isAuthenticated: !!token,
+        isLoading,
+        login,
+        logout,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+// ── Hook ───────────────────────────────────────────────────────
+
+export function useAuth(): AuthContextType {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth() must be used inside <AuthProvider>');
+  return ctx;
+}

--- a/frontend/field-force-contractor/screens/LoginScreen.tsx
+++ b/frontend/field-force-contractor/screens/LoginScreen.tsx
@@ -16,6 +16,7 @@ import {
   KeyboardAvoidingView,
   Platform,
   ScrollView,
+  ActivityIndicator,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
@@ -23,17 +24,12 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../App';
 import { FieldForceHeader } from '../components/FieldForceHeader';
 import { colors, spacing, radius, fontSize, fonts } from '../constants/theme';
+import { api, LoginResponse, ApiError } from '../utils/api';
+import { useAuth } from '../contexts/AuthContext';
 
 // This tells TypeScript what screen we're on so navigation.navigate()
 // knows which screens are valid to go to from here
 type Nav = NativeStackNavigationProp<RootStackParamList, 'Login'>;
-
-// ---------------------------------------------------------------
-// DEV ONLY — these are test credentials so we can log in quickly
-// during development. Delete these before going to production!
-// ---------------------------------------------------------------
-const DEV_EMAIL    = 'test@test.com';
-const DEV_PASSWORD = '123456';
 
 // A simple function to check if an email looks valid.
 // It uses a "regex" (regular expression) to check the format.
@@ -45,12 +41,13 @@ const isValidEmail = (email: string) => {
 
 export default function LoginScreen() {
   const navigation = useNavigation<Nav>();
+  const { login }  = useAuth();
 
   // useState stores values that can change. When they change, the screen re-renders.
-  // We pre-fill with dev credentials so testers don't have to type every time.
-  const [email,        setEmail]        = useState(DEV_EMAIL);
-  const [password,     setPassword]     = useState(DEV_PASSWORD);
+  const [email,        setEmail]        = useState('');
+  const [password,     setPassword]     = useState('');
   const [showPassword, setShowPassword] = useState(false); // toggles the eye icon
+  const [isSubmitting, setIsSubmitting] = useState(false);  // shows spinner on button
 
   // These hold error messages. Empty string '' means no error to show.
   const [emailError,    setEmailError]    = useState('');
@@ -94,7 +91,7 @@ export default function LoginScreen() {
   }
 
   // This runs when the user taps the Login button
-  const handleLogin = () => {
+  const handleLogin = async () => {
     // First check if both fields are valid before doing anything
     let everythingIsValid = true;
 
@@ -123,22 +120,33 @@ export default function LoginScreen() {
       return;
     }
 
-    // ---------------------------------------------------------------
-    // DEV credential check — replace this with a real API call later.
-    // In production, you'd send the email and password to your backend
-    // and it would tell you if they're correct.
-    // ---------------------------------------------------------------
-    const emailMatches    = email.trim().toLowerCase() === DEV_EMAIL;
-    const passwordMatches = password === DEV_PASSWORD;
-
-    if (!emailMatches || !passwordMatches) {
-      setLoginError('The email or password you entered is incorrect. Please try again.');
-      return;
-    }
-
-    // If we get here, credentials are correct — go to biometric check
+    // ── Call the real backend /auth/login endpoint ─────────────
+    setIsSubmitting(true);
     setLoginError('');
-    navigation.navigate('BiometricCheck');
+
+    try {
+      const res = await api.post<LoginResponse>('/auth/login', {
+        username: email.trim(),   // backend expects "username" field
+        password,
+      });
+
+      // Store JWT + user info in AuthContext (persists to SecureStore)
+      await login(res.token, res.user);
+
+      // Credentials are correct — go to biometric check
+      navigation.navigate('BiometricCheck');
+    } catch (err) {
+      const apiErr = err as ApiError;
+      if (apiErr.status === 401) {
+        setLoginError('The email or password you entered is incorrect. Please try again.');
+      } else if (apiErr.status === 0) {
+        setLoginError('Unable to reach the server. Check your internet connection.');
+      } else {
+        setLoginError(apiErr.error || 'Something went wrong. Please try again.');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
   }
 
   // The Login button should look "active" only when both fields look valid
@@ -267,13 +275,18 @@ export default function LoginScreen() {
               )}
             </View>
 
-            {/* Login button — appears grayed out when the form isn't ready */}
+            {/* Login button — appears grayed out when the form isn't ready or submitting */}
             <TouchableOpacity
-              style={[styles.loginBtn, !formLooksReady && styles.btnDisabled]}
+              style={[styles.loginBtn, (!formLooksReady || isSubmitting) && styles.btnDisabled]}
               onPress={handleLogin}
               activeOpacity={0.85}
+              disabled={isSubmitting}
             >
-              <Text style={styles.loginBtnText}>Login</Text>
+              {isSubmitting ? (
+                <ActivityIndicator color={colors.textWhite} />
+              ) : (
+                <Text style={styles.loginBtnText}>Login</Text>
+              )}
             </TouchableOpacity>
 
             {/* Visual separator between Login and Forgot Password */}

--- a/frontend/field-force-contractor/screens/ProfileScreen.tsx
+++ b/frontend/field-force-contractor/screens/ProfileScreen.tsx
@@ -7,18 +7,14 @@
 //   2. Contact info (email, phone, address)
 //   3. Menu rows (License, Settings, Logout)
 
-import { useState } from 'react';
 import {
   View,
   Text,
-  TextInput,
   TouchableOpacity,
   StyleSheet,
   SafeAreaView,
   StatusBar,
   ScrollView,
-  Alert,
-  ActivityIndicator,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
@@ -28,7 +24,6 @@ import { FieldForceHeader, SubHeader } from '../components/FieldForceHeader';
 import { BottomNavigation } from '../components/BottomNavigation';
 import { colors, spacing, radius, fontSize, fonts } from '../constants/theme';
 import { useAuth } from '../contexts/AuthContext';
-import { api, ApiError } from '../utils/api';
 
 type Nav = NativeStackNavigationProp<RootStackParamList, 'Profile'>;
 
@@ -138,41 +133,7 @@ const menuStyles = StyleSheet.create({
 // ---------------------------------------------------------------
 export default function ProfileScreen() {
   const navigation = useNavigation<Nav>();
-  const { user, logout } = useAuth();
-
-  // ── Offline PIN state ──────────────────────────────────────
-  const [pin,            setPin]            = useState('');
-  const [confirmPin,     setConfirmPin]     = useState('');
-  const [pinError,       setPinError]       = useState('');
-  const [pinSuccess,     setPinSuccess]     = useState('');
-  const [isSavingPin,    setIsSavingPin]    = useState(false);
-
-  const handleSavePin = async () => {
-    setPinError('');
-    setPinSuccess('');
-
-    if (pin.length < 4) {
-      setPinError('PIN must be at least 4 digits.');
-      return;
-    }
-    if (pin !== confirmPin) {
-      setPinError('PINs do not match.');
-      return;
-    }
-
-    setIsSavingPin(true);
-    try {
-      await api.authPost('/auth/offline-pin', { pin });
-      setPinSuccess('Offline PIN saved successfully!');
-      setPin('');
-      setConfirmPin('');
-    } catch (err) {
-      const apiErr = err as ApiError;
-      setPinError(apiErr.error || 'Failed to save PIN. Please try again.');
-    } finally {
-      setIsSavingPin(false);
-    }
-  };
+  const { logout } = useAuth();
 
   const handleLogout = async () => {
     await logout();           // clears JWT from SecureStore + AuthContext
@@ -211,61 +172,6 @@ export default function ProfileScreen() {
           <InfoRow icon="camera-outline"   label="Email"   value={CONTRACTOR.email}   />
           <InfoRow icon="call-outline"     label="Phone"   value={CONTRACTOR.phone}   />
           <InfoRow icon="location-outline" label="Address" value={CONTRACTOR.address} />
-        </View>
-
-        {/* ── Offline PIN setup section ────────────────────── */}
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Offline PIN</Text>
-          <Text style={styles.sectionHint}>
-            Set a 4+ digit PIN so you can log in when you have no internet.
-          </Text>
-
-          <TextInput
-            style={styles.pinInput}
-            value={pin}
-            onChangeText={(v) => { setPin(v); setPinError(''); setPinSuccess(''); }}
-            placeholder="Enter PIN"
-            placeholderTextColor={colors.textMuted}
-            keyboardType="number-pad"
-            secureTextEntry
-            maxLength={8}
-          />
-          <TextInput
-            style={styles.pinInput}
-            value={confirmPin}
-            onChangeText={(v) => { setConfirmPin(v); setPinError(''); setPinSuccess(''); }}
-            placeholder="Confirm PIN"
-            placeholderTextColor={colors.textMuted}
-            keyboardType="number-pad"
-            secureTextEntry
-            maxLength={8}
-          />
-
-          {pinError !== '' && (
-            <View style={styles.pinMsgRow}>
-              <Ionicons name="alert-circle-outline" size={14} color={colors.error} />
-              <Text style={[styles.pinMsgText, { color: colors.error }]}>{pinError}</Text>
-            </View>
-          )}
-          {pinSuccess !== '' && (
-            <View style={styles.pinMsgRow}>
-              <Ionicons name="checkmark-circle-outline" size={14} color={colors.success} />
-              <Text style={[styles.pinMsgText, { color: colors.success }]}>{pinSuccess}</Text>
-            </View>
-          )}
-
-          <TouchableOpacity
-            style={[styles.pinSaveBtn, isSavingPin && styles.pinSaveBtnDisabled]}
-            onPress={handleSavePin}
-            disabled={isSavingPin}
-            activeOpacity={0.85}
-          >
-            {isSavingPin ? (
-              <ActivityIndicator color={colors.textWhite} />
-            ) : (
-              <Text style={styles.pinSaveBtnText}>Save PIN</Text>
-            )}
-          </TouchableOpacity>
         </View>
 
         {/* ── Menu section ─────────────────────────────────── */}
@@ -326,52 +232,4 @@ const styles = StyleSheet.create({
 
   // Each section (contact, menu) has some horizontal padding and spacing between rows
   section: { gap: spacing.sm, paddingHorizontal: spacing.md },
-
-  // ── Offline PIN styles ──────────────────────────────────────
-  sectionTitle: {
-    fontFamily: fonts.bold,
-    fontSize:   fontSize.base,
-    color:      colors.textWhite,
-  },
-  sectionHint: {
-    fontFamily: fonts.regular,
-    fontSize:   fontSize.xs,
-    color:      colors.textMuted,
-    marginBottom: 4,
-  },
-  pinInput: {
-    backgroundColor:   colors.card,
-    borderRadius:      radius.md,
-    borderWidth:       1,
-    borderColor:       colors.border,
-    paddingHorizontal: spacing.md,
-    paddingVertical:   12,
-    fontFamily:        fonts.regular,
-    color:             colors.textWhite,
-    fontSize:          fontSize.base,
-    letterSpacing:     6,
-    textAlign:         'center',
-  },
-  pinMsgRow: {
-    flexDirection: 'row',
-    alignItems:    'center',
-    gap:           5,
-  },
-  pinMsgText: {
-    fontFamily: fonts.regular,
-    fontSize:   fontSize.xs,
-    flex:       1,
-  },
-  pinSaveBtn: {
-    backgroundColor: colors.primary,
-    borderRadius:    radius.md,
-    paddingVertical: 13,
-    alignItems:      'center',
-  },
-  pinSaveBtnDisabled: { backgroundColor: colors.cardAlt },
-  pinSaveBtnText: {
-    fontFamily: fonts.bold,
-    color:      colors.textWhite,
-    fontSize:   fontSize.sm,
-  },
 });

--- a/frontend/field-force-contractor/screens/ProfileScreen.tsx
+++ b/frontend/field-force-contractor/screens/ProfileScreen.tsx
@@ -7,14 +7,18 @@
 //   2. Contact info (email, phone, address)
 //   3. Menu rows (License, Settings, Logout)
 
+import { useState } from 'react';
 import {
   View,
   Text,
+  TextInput,
   TouchableOpacity,
   StyleSheet,
   SafeAreaView,
   StatusBar,
   ScrollView,
+  Alert,
+  ActivityIndicator,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
@@ -23,6 +27,8 @@ import { RootStackParamList } from '../App';
 import { FieldForceHeader, SubHeader } from '../components/FieldForceHeader';
 import { BottomNavigation } from '../components/BottomNavigation';
 import { colors, spacing, radius, fontSize, fonts } from '../constants/theme';
+import { useAuth } from '../contexts/AuthContext';
+import { api, ApiError } from '../utils/api';
 
 type Nav = NativeStackNavigationProp<RootStackParamList, 'Profile'>;
 
@@ -132,12 +138,46 @@ const menuStyles = StyleSheet.create({
 // ---------------------------------------------------------------
 export default function ProfileScreen() {
   const navigation = useNavigation<Nav>();
+  const { user, logout } = useAuth();
 
-  const handleLogout = () => {
-    // TODO: Clear auth tokens and any stored user data before navigating away.
-    // For example: await SecureStore.deleteItemAsync('authToken');
+  // ── Offline PIN state ──────────────────────────────────────
+  const [pin,            setPin]            = useState('');
+  const [confirmPin,     setConfirmPin]     = useState('');
+  const [pinError,       setPinError]       = useState('');
+  const [pinSuccess,     setPinSuccess]     = useState('');
+  const [isSavingPin,    setIsSavingPin]    = useState(false);
+
+  const handleSavePin = async () => {
+    setPinError('');
+    setPinSuccess('');
+
+    if (pin.length < 4) {
+      setPinError('PIN must be at least 4 digits.');
+      return;
+    }
+    if (pin !== confirmPin) {
+      setPinError('PINs do not match.');
+      return;
+    }
+
+    setIsSavingPin(true);
+    try {
+      await api.authPost('/auth/offline-pin', { pin });
+      setPinSuccess('Offline PIN saved successfully!');
+      setPin('');
+      setConfirmPin('');
+    } catch (err) {
+      const apiErr = err as ApiError;
+      setPinError(apiErr.error || 'Failed to save PIN. Please try again.');
+    } finally {
+      setIsSavingPin(false);
+    }
+  };
+
+  const handleLogout = async () => {
+    await logout();           // clears JWT from SecureStore + AuthContext
     navigation.replace('Login');
-  }
+  };
 
   return (
     <SafeAreaView style={styles.container}>
@@ -171,6 +211,61 @@ export default function ProfileScreen() {
           <InfoRow icon="camera-outline"   label="Email"   value={CONTRACTOR.email}   />
           <InfoRow icon="call-outline"     label="Phone"   value={CONTRACTOR.phone}   />
           <InfoRow icon="location-outline" label="Address" value={CONTRACTOR.address} />
+        </View>
+
+        {/* ── Offline PIN setup section ────────────────────── */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Offline PIN</Text>
+          <Text style={styles.sectionHint}>
+            Set a 4+ digit PIN so you can log in when you have no internet.
+          </Text>
+
+          <TextInput
+            style={styles.pinInput}
+            value={pin}
+            onChangeText={(v) => { setPin(v); setPinError(''); setPinSuccess(''); }}
+            placeholder="Enter PIN"
+            placeholderTextColor={colors.textMuted}
+            keyboardType="number-pad"
+            secureTextEntry
+            maxLength={8}
+          />
+          <TextInput
+            style={styles.pinInput}
+            value={confirmPin}
+            onChangeText={(v) => { setConfirmPin(v); setPinError(''); setPinSuccess(''); }}
+            placeholder="Confirm PIN"
+            placeholderTextColor={colors.textMuted}
+            keyboardType="number-pad"
+            secureTextEntry
+            maxLength={8}
+          />
+
+          {pinError !== '' && (
+            <View style={styles.pinMsgRow}>
+              <Ionicons name="alert-circle-outline" size={14} color={colors.error} />
+              <Text style={[styles.pinMsgText, { color: colors.error }]}>{pinError}</Text>
+            </View>
+          )}
+          {pinSuccess !== '' && (
+            <View style={styles.pinMsgRow}>
+              <Ionicons name="checkmark-circle-outline" size={14} color={colors.success} />
+              <Text style={[styles.pinMsgText, { color: colors.success }]}>{pinSuccess}</Text>
+            </View>
+          )}
+
+          <TouchableOpacity
+            style={[styles.pinSaveBtn, isSavingPin && styles.pinSaveBtnDisabled]}
+            onPress={handleSavePin}
+            disabled={isSavingPin}
+            activeOpacity={0.85}
+          >
+            {isSavingPin ? (
+              <ActivityIndicator color={colors.textWhite} />
+            ) : (
+              <Text style={styles.pinSaveBtnText}>Save PIN</Text>
+            )}
+          </TouchableOpacity>
         </View>
 
         {/* ── Menu section ─────────────────────────────────── */}
@@ -231,4 +326,52 @@ const styles = StyleSheet.create({
 
   // Each section (contact, menu) has some horizontal padding and spacing between rows
   section: { gap: spacing.sm, paddingHorizontal: spacing.md },
+
+  // ── Offline PIN styles ──────────────────────────────────────
+  sectionTitle: {
+    fontFamily: fonts.bold,
+    fontSize:   fontSize.base,
+    color:      colors.textWhite,
+  },
+  sectionHint: {
+    fontFamily: fonts.regular,
+    fontSize:   fontSize.xs,
+    color:      colors.textMuted,
+    marginBottom: 4,
+  },
+  pinInput: {
+    backgroundColor:   colors.card,
+    borderRadius:      radius.md,
+    borderWidth:       1,
+    borderColor:       colors.border,
+    paddingHorizontal: spacing.md,
+    paddingVertical:   12,
+    fontFamily:        fonts.regular,
+    color:             colors.textWhite,
+    fontSize:          fontSize.base,
+    letterSpacing:     6,
+    textAlign:         'center',
+  },
+  pinMsgRow: {
+    flexDirection: 'row',
+    alignItems:    'center',
+    gap:           5,
+  },
+  pinMsgText: {
+    fontFamily: fonts.regular,
+    fontSize:   fontSize.xs,
+    flex:       1,
+  },
+  pinSaveBtn: {
+    backgroundColor: colors.primary,
+    borderRadius:    radius.md,
+    paddingVertical: 13,
+    alignItems:      'center',
+  },
+  pinSaveBtnDisabled: { backgroundColor: colors.cardAlt },
+  pinSaveBtnText: {
+    fontFamily: fonts.bold,
+    color:      colors.textWhite,
+    fontSize:   fontSize.sm,
+  },
 });

--- a/frontend/field-force-contractor/utils/api.ts
+++ b/frontend/field-force-contractor/utils/api.ts
@@ -1,0 +1,118 @@
+// api.ts
+// Central HTTP client for all backend requests.
+// Automatically attaches the stored JWT when requiresAuth = true,
+// and throws a typed ApiError on non-2xx responses.
+
+import { Platform } from 'react-native';
+import { getToken } from './secureStorage';
+
+// ── Config ─────────────────────────────────────────────────────
+const LAN_IP = '10.0.0.152';            // ← your machine's Wi-Fi LAN IP
+const PORT   = 5000;
+
+function resolveBaseUrl(): string {
+  if (__DEV__) {
+    if (Platform.OS === 'android') return `http://10.0.2.2:${PORT}`;
+    if (Platform.OS === 'ios')     return `http://localhost:${PORT}`;
+  }
+  return `http://${LAN_IP}:${PORT}`;
+}
+
+export const API_BASE_URL = resolveBaseUrl();
+
+// ── Types ──────────────────────────────────────────────────────
+
+export interface ApiError {
+  status: number;
+  error:  string;
+  code?:  string;
+}
+
+export interface LoginPayload {
+  username: string;
+  password: string;
+}
+
+export interface UserInfo {
+  id:       number;
+  username: string;
+  role:     string;
+}
+
+export interface LoginResponse {
+  message: string;
+  token:   string;
+  user:    UserInfo;
+}
+
+// ── Core request helper ────────────────────────────────────────
+
+async function request<T>(
+  path:         string,
+  options:      RequestInit = {},
+  requiresAuth: boolean     = false,
+): Promise<T> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(options.headers as Record<string, string> | undefined),
+  };
+
+  if (requiresAuth) {
+    const token = await getToken();
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
+  } catch {
+    throw {
+      status: 0,
+      error:  'Unable to reach the server. Check your internet connection.',
+    } as ApiError;
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    body = {};
+  }
+
+  if (!response.ok) {
+    const err = body as Partial<ApiError>;
+    throw {
+      status: response.status,
+      error:  err.error  ?? `Request failed with status ${response.status}`,
+      code:   err.code,
+    } as ApiError;
+  }
+
+  return body as T;
+}
+
+// ── Public API surface ─────────────────────────────────────────
+
+export const api = {
+  post<T>(path: string, body: unknown): Promise<T> {
+    return request<T>(path, { method: 'POST', body: JSON.stringify(body) });
+  },
+
+  authPost<T>(path: string, body: unknown): Promise<T> {
+    return request<T>(path, { method: 'POST', body: JSON.stringify(body) }, true);
+  },
+
+  authGet<T>(path: string): Promise<T> {
+    return request<T>(path, { method: 'GET' }, true);
+  },
+
+  authPut<T>(path: string, body: unknown): Promise<T> {
+    return request<T>(path, { method: 'PUT', body: JSON.stringify(body) }, true);
+  },
+
+  authPatch<T>(path: string, body: unknown): Promise<T> {
+    return request<T>(path, { method: 'PATCH', body: JSON.stringify(body) }, true);
+  },
+};

--- a/frontend/field-force-contractor/utils/secureStorage.ts
+++ b/frontend/field-force-contractor/utils/secureStorage.ts
@@ -1,0 +1,35 @@
+// secureStorage.ts
+// Thin wrapper around expo-secure-store for tokens and PINs.
+
+import * as SecureStore from 'expo-secure-store';
+
+const TOKEN_KEY       = 'auth_token';
+const OFFLINE_PIN_KEY = 'offline_pin';
+
+// ── Token helpers ──────────────────────────────────────────────
+
+export async function saveToken(token: string): Promise<void> {
+  await SecureStore.setItemAsync(TOKEN_KEY, token);
+}
+
+export async function getToken(): Promise<string | null> {
+  return SecureStore.getItemAsync(TOKEN_KEY);
+}
+
+export async function deleteToken(): Promise<void> {
+  await SecureStore.deleteItemAsync(TOKEN_KEY);
+}
+
+// ── Offline PIN helpers ────────────────────────────────────────
+
+export async function saveOfflinePin(pin: string): Promise<void> {
+  await SecureStore.setItemAsync(OFFLINE_PIN_KEY, pin);
+}
+
+export async function getOfflinePin(): Promise<string | null> {
+  return SecureStore.getItemAsync(OFFLINE_PIN_KEY);
+}
+
+export async function deleteOfflinePin(): Promise<void> {
+  await SecureStore.deleteItemAsync(OFFLINE_PIN_KEY);
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded DEV credentials in LoginScreen with real /auth/login API call
- Add AuthContext provider for app-wide JWT state (persisted via expo-secure-store)
- Add api.ts HTTP client with auto-detecting base URL per platform
- Add secureStorage.ts wrapper for token storage
- Wire ProfileScreen logout to clear JWT from SecureStore

## Test plan
- Start backend with valid .env, start Expo dev server
- Login with valid credentials — should navigate to BiometricCheck
- Login with wrong credentials — should show error banner
- Logout from ProfileScreen — should clear token and return to Login

Relates to #139