### PR TITLE
Add inspection system + skipped flag support

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -6,6 +6,7 @@ from .blueprints.auth_users import auth_users_bp
 from .blueprints.field_contractors import field_contractors_bp
 from .blueprints.tickets import tickets_bp
 from .blueprints.work_orders import work_orders_bp
+from .blueprints.inspections import inspections_bp
 
 
 def create_app(config_name):
@@ -23,6 +24,7 @@ def create_app(config_name):
     app.register_blueprint(tickets_bp, url_prefix='/tickets')
 
     app.register_blueprint(work_orders_bp, url_prefix='/api/work-orders')
+    app.register_blueprint(inspections_bp, url_prefix='/inspections')
 
-   
+
     return app

--- a/backend/app/blueprints/inspections/__init__.py
+++ b/backend/app/blueprints/inspections/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+inspections_bp = Blueprint('inspections_bp', __name__)
+
+from . import routes

--- a/backend/app/blueprints/inspections/routes.py
+++ b/backend/app/blueprints/inspections/routes.py
@@ -69,7 +69,9 @@ def submit_inspection():
         return jsonify({'error': 'Inspection template not found.'}), 404
 
     # Determine overall status
-    if data['no_issues_found']:
+    if data['skipped']:
+        status = 'skipped'
+    elif data['no_issues_found']:
         status = 'passed'
     else:
         # If any item failed, the inspection status is 'failed'
@@ -81,13 +83,17 @@ def submit_inspection():
         contractor_id=request.user_id,
         status=status,
         no_issues_found=data['no_issues_found'],
+        skipped=data['skipped'],
         submitted_at=datetime.now(timezone.utc),
         notes=data.get('notes'),
     )
     db.session.add(inspection)
     db.session.flush()  # get the inspection.id before adding results
 
-    if data['no_issues_found']:
+    if data['skipped']:
+        # User tapped X to skip. Record the bypass but don't create item results.
+        pass
+    elif data['no_issues_found']:
         # Auto-create passed results for every item in the template
         all_items = (
             db.session.query(InspectionItems)

--- a/backend/app/blueprints/inspections/routes.py
+++ b/backend/app/blueprints/inspections/routes.py
@@ -1,0 +1,181 @@
+from flask import request, jsonify
+from app.models import (
+    InspectionTemplates, InspectionSections, InspectionItems,
+    Inspections, InspectionResults, db,
+)
+from .schemas import (
+    template_schema, templates_schema,
+    inspection_schema, inspections_schema,
+    submit_schema,
+)
+from marshmallow import ValidationError
+from . import inspections_bp
+from app.util.auth import token_required
+from datetime import datetime, timezone
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GET /inspections/checklist
+# Returns the active inspection template with all sections and items.
+# The frontend renders this dynamically — no hardcoded checklist.
+# ─────────────────────────────────────────────────────────────────────────────
+@inspections_bp.route('/checklist', methods=['GET'])
+@token_required
+def get_checklist():
+    template = db.session.query(InspectionTemplates).filter_by(is_active=True).first()
+
+    if not template:
+        return jsonify({'error': 'No active inspection template found.'}), 404
+
+    return template_schema.jsonify(template), 200
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GET /inspections/templates
+# Returns all templates (active and inactive) for admin management.
+# ─────────────────────────────────────────────────────────────────────────────
+@inspections_bp.route('/templates', methods=['GET'])
+@token_required
+def get_all_templates():
+    templates = db.session.query(InspectionTemplates).all()
+    return templates_schema.jsonify(templates), 200
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# POST /inspections/submit
+# Contractor submits an inspection.
+#
+# If no_issues_found = true:
+#   All items are auto-marked as passed. No individual results needed.
+#
+# If no_issues_found = false:
+#   The "results" array must contain per-item pass/fail data.
+# ─────────────────────────────────────────────────────────────────────────────
+@inspections_bp.route('/submit', methods=['POST'])
+@token_required
+def submit_inspection():
+    json_data = request.get_json()
+    if not json_data:
+        return jsonify({'error': 'No input data provided.'}), 400
+
+    try:
+        data = submit_schema.load(json_data)
+    except ValidationError as e:
+        return jsonify(e.messages), 400
+
+    # Verify template exists
+    template = db.session.get(InspectionTemplates, data['template_id'])
+    if not template:
+        return jsonify({'error': 'Inspection template not found.'}), 404
+
+    # Determine overall status
+    if data['no_issues_found']:
+        status = 'passed'
+    else:
+        # If any item failed, the inspection status is 'failed'
+        has_failure = any(r.get('passed') is False for r in data.get('results', []))
+        status = 'failed' if has_failure else 'passed'
+
+    inspection = Inspections(
+        template_id=data['template_id'],
+        contractor_id=request.user_id,
+        status=status,
+        no_issues_found=data['no_issues_found'],
+        submitted_at=datetime.now(timezone.utc),
+        notes=data.get('notes'),
+    )
+    db.session.add(inspection)
+    db.session.flush()  # get the inspection.id before adding results
+
+    if data['no_issues_found']:
+        # Auto-create passed results for every item in the template
+        all_items = (
+            db.session.query(InspectionItems)
+            .join(InspectionSections)
+            .filter(InspectionSections.template_id == data['template_id'])
+            .all()
+        )
+        for item in all_items:
+            result = InspectionResults(
+                inspection_id=inspection.id,
+                item_id=item.id,
+                passed=True,
+            )
+            db.session.add(result)
+    else:
+        # Save individual item results from the request
+        for r in data.get('results', []):
+            # Verify item belongs to this template
+            item = db.session.get(InspectionItems, r['item_id'])
+            if not item:
+                db.session.rollback()
+                return jsonify({'error': f'Item {r["item_id"]} not found.'}), 400
+
+            result = InspectionResults(
+                inspection_id=inspection.id,
+                item_id=r['item_id'],
+                passed=r['passed'],
+                note=r.get('note'),
+            )
+            db.session.add(result)
+
+    db.session.commit()
+
+    return inspection_schema.jsonify(inspection), 201
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GET /inspections/latest
+# Returns the contractor's most recent inspection.
+# Used by the app to decide if the contractor needs to inspect before shift.
+# ─────────────────────────────────────────────────────────────────────────────
+@inspections_bp.route('/latest', methods=['GET'])
+@token_required
+def get_latest_inspection():
+    inspection = (
+        db.session.query(Inspections)
+        .filter_by(contractor_id=request.user_id)
+        .order_by(Inspections.created_at.desc())
+        .first()
+    )
+
+    if not inspection:
+        return jsonify({'message': 'No inspections found.'}), 404
+
+    return inspection_schema.jsonify(inspection), 200
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GET /inspections/<id>
+# Returns a specific inspection by ID.
+# ─────────────────────────────────────────────────────────────────────────────
+@inspections_bp.route('/<int:inspection_id>', methods=['GET'])
+@token_required
+def get_inspection(inspection_id):
+    inspection = db.session.get(Inspections, inspection_id)
+
+    if not inspection:
+        return jsonify({'error': 'Inspection not found.'}), 404
+
+    # Only allow the contractor who submitted it to view it
+    if inspection.contractor_id != request.user_id:
+        return jsonify({'error': 'Unauthorized.'}), 403
+
+    return inspection_schema.jsonify(inspection), 200
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GET /inspections/history
+# Returns all inspections for the logged-in contractor.
+# ─────────────────────────────────────────────────────────────────────────────
+@inspections_bp.route('/history', methods=['GET'])
+@token_required
+def get_inspection_history():
+    inspections = (
+        db.session.query(Inspections)
+        .filter_by(contractor_id=request.user_id)
+        .order_by(Inspections.created_at.desc())
+        .all()
+    )
+
+    return inspections_schema.jsonify(inspections), 200

--- a/backend/app/blueprints/inspections/schemas.py
+++ b/backend/app/blueprints/inspections/schemas.py
@@ -1,0 +1,67 @@
+from app.extensions import ma
+from app.models import InspectionTemplates, InspectionSections, InspectionItems, Inspections, InspectionResults
+from marshmallow import fields, Schema, validate
+
+
+# ── Read schemas (for GET responses) ──────────────────────────────────────────
+
+class InspectionItemSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = InspectionItems
+        include_fk = True
+
+
+class InspectionSectionSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = InspectionSections
+        include_fk = True
+
+    items = fields.Nested(InspectionItemSchema, many=True)
+
+
+class InspectionTemplateSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = InspectionTemplates
+        include_fk = True
+
+    sections = fields.Nested(InspectionSectionSchema, many=True)
+
+
+class InspectionResultSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = InspectionResults
+        include_fk = True
+
+
+class InspectionSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Inspections
+        include_fk = True
+
+    results = fields.Nested(InspectionResultSchema, many=True)
+
+
+# ── Write schemas (for POST request validation) ──────────────────────────────
+
+class ItemResultInputSchema(Schema):
+    """One item result inside a submission."""
+    item_id = fields.Int(required=True)
+    passed = fields.Bool(required=True)
+    note = fields.Str(required=False, load_default=None)
+
+
+class InspectionSubmitSchema(Schema):
+    """Payload for submitting an inspection."""
+    template_id = fields.Int(required=True)
+    no_issues_found = fields.Bool(required=True)
+    results = fields.List(fields.Nested(ItemResultInputSchema), required=False, load_default=[])
+    notes = fields.Str(required=False, load_default=None)
+
+
+# ── Instances ─────────────────────────────────────────────────────────────────
+
+template_schema = InspectionTemplateSchema()
+templates_schema = InspectionTemplateSchema(many=True)
+inspection_schema = InspectionSchema()
+inspections_schema = InspectionSchema(many=True)
+submit_schema = InspectionSubmitSchema()

--- a/backend/app/blueprints/inspections/schemas.py
+++ b/backend/app/blueprints/inspections/schemas.py
@@ -51,9 +51,17 @@ class ItemResultInputSchema(Schema):
 
 
 class InspectionSubmitSchema(Schema):
-    """Payload for submitting an inspection."""
+    """Payload for submitting an inspection.
+
+    - no_issues_found=true  → all items auto-marked as passed.
+    - skipped=true          → user tapped the X on the modal. No results created.
+                              Status is recorded as 'skipped' so leadership can
+                              still see who bypassed the inspection.
+    - Otherwise             → per-item results[] must be provided.
+    """
     template_id = fields.Int(required=True)
-    no_issues_found = fields.Bool(required=True)
+    no_issues_found = fields.Bool(required=False, load_default=False)
+    skipped = fields.Bool(required=False, load_default=False)
     results = fields.List(fields.Nested(ItemResultInputSchema), required=False, load_default=[])
     notes = fields.Str(required=False, load_default=None)
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -145,8 +145,9 @@ class Inspections(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     template_id: Mapped[int] = mapped_column(ForeignKey('inspection_templates.id'), nullable=False)
     contractor_id: Mapped[int] = mapped_column(ForeignKey('contractors.id'), nullable=False)
-    status: Mapped[str] = mapped_column(String(20), nullable=False, default='pending')  # pending, passed, failed
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default='pending')  # pending, passed, failed, skipped
     no_issues_found: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    skipped: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     submitted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now(timezone.utc), nullable=False)
     notes: Mapped[str] = mapped_column(String(1000), nullable=True)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -96,6 +96,79 @@ class Tickets(Base):
 
 #vendors and clients to be updated
 
+# ── Inspection models ─────────────────────────────────────────────────────────
+# Checklist sections and items are stored in the DB so vendors/admins can
+# configure them dynamically — no code changes needed to add a new section.
+
+class InspectionTemplates(Base):
+    """A named checklist template (e.g. 'Truck Pre-Trip Inspection')."""
+    __tablename__ = 'inspection_templates'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    description: Mapped[str] = mapped_column(String(500), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now(timezone.utc), nullable=False)
+
+    sections = relationship("InspectionSections", back_populates="template", order_by="InspectionSections.display_order")
+
+
+class InspectionSections(Base):
+    """A section within a template (e.g. 'Engine Compartment', 'Lights Check')."""
+    __tablename__ = 'inspection_sections'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    template_id: Mapped[int] = mapped_column(ForeignKey('inspection_templates.id'), nullable=False)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    display_order: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+
+    template = relationship("InspectionTemplates", back_populates="sections")
+    items = relationship("InspectionItems", back_populates="section", order_by="InspectionItems.display_order")
+
+
+class InspectionItems(Base):
+    """An individual check within a section (e.g. 'Check oil level')."""
+    __tablename__ = 'inspection_items'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    section_id: Mapped[int] = mapped_column(ForeignKey('inspection_sections.id'), nullable=False)
+    label: Mapped[str] = mapped_column(String(300), nullable=False)
+    display_order: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+
+    section = relationship("InspectionSections", back_populates="items")
+
+
+class Inspections(Base):
+    """A completed (or in-progress) inspection by a contractor."""
+    __tablename__ = 'inspections'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    template_id: Mapped[int] = mapped_column(ForeignKey('inspection_templates.id'), nullable=False)
+    contractor_id: Mapped[int] = mapped_column(ForeignKey('contractors.id'), nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default='pending')  # pending, passed, failed
+    no_issues_found: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    submitted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now(timezone.utc), nullable=False)
+    notes: Mapped[str] = mapped_column(String(1000), nullable=True)
+
+    template = relationship("InspectionTemplates")
+    results = relationship("InspectionResults", back_populates="inspection")
+
+
+class InspectionResults(Base):
+    """Per-item result for an inspection (passed or failed + optional note)."""
+    __tablename__ = 'inspection_results'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    inspection_id: Mapped[int] = mapped_column(ForeignKey('inspections.id'), nullable=False)
+    item_id: Mapped[int] = mapped_column(ForeignKey('inspection_items.id'), nullable=False)
+    passed: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    note: Mapped[str] = mapped_column(String(500), nullable=True)
+
+    inspection = relationship("Inspections", back_populates="results")
+    item = relationship("InspectionItems")
+
+
 class Vendors(Base):
     __tablename__ = 'vendors'
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,3 +20,4 @@ typing_extensions==4.15.0
 Werkzeug==3.1.6
 python-dotenv==1.0.1
 Flask-Cors==5.0.1
+gunicorn==23.0.0

--- a/backend/seed_inspections.py
+++ b/backend/seed_inspections.py
@@ -1,0 +1,107 @@
+"""
+Seed script for the Truck Pre-Trip Inspection template.
+Run once to populate the inspection_templates, inspection_sections, and
+inspection_items tables with the standard checklist from the Figma design.
+
+Usage:
+    python seed_inspections.py
+"""
+from dotenv import load_dotenv
+load_dotenv()
+
+from app import create_app
+from app.models import db, InspectionTemplates, InspectionSections, InspectionItems
+
+app = create_app('DevelopmentConfig')
+
+SECTIONS = [
+    ('Engine Compartment', 1, [
+        'Check oil level',
+        'Check coolant level',
+        'Inspect belts (no cracks/fraying)',
+        'Check hoses for leaks',
+        'Power steering fluid',
+        'Windshield washer fluid',
+    ]),
+    ('Lights Check', 2, [
+        'Headlights (high and low beam)',
+        'Tail lights',
+        'Brake lights',
+        'Turn signals (front and rear)',
+        'Hazard lights',
+        'Clearance/marker lights',
+    ]),
+    ('Front of Vehicle', 3, [
+        'Windshield condition (no cracks)',
+        'Wiper blades condition',
+        'Front bumper secure',
+        'License plate visible and secure',
+        'Mirrors clean and adjusted',
+    ]),
+    ('Driver Side', 4, [
+        'Door opens/closes properly',
+        'Window operates correctly',
+        'Mirror secure and clean',
+        'Fuel cap secure',
+        'Steps/handrails secure',
+    ]),
+    ('Wheels & Tires', 5, [
+        'Tire pressure adequate',
+        'Tread depth sufficient',
+        'No cuts, bulges, or damage',
+        'Lug nuts tight',
+        'Valve stems intact',
+        'Spare tire present and inflated',
+    ]),
+    ('Brake System Check', 6, [
+        'Brake pedal firm',
+        'Parking brake holds',
+        'Air brake pressure builds properly',
+        'No air leaks detected',
+        'Brake lines/hoses intact',
+    ]),
+]
+
+
+def seed():
+    with app.app_context():
+        existing = db.session.query(InspectionTemplates).filter_by(
+            name='Truck Pre-Trip Inspection'
+        ).first()
+
+        if existing:
+            print('Template already exists — skipping.')
+            return
+
+        template = InspectionTemplates(
+            name='Truck Pre-Trip Inspection',
+            description='Standard pre-trip vehicle inspection checklist',
+        )
+        db.session.add(template)
+        db.session.flush()
+
+        for section_name, order, items in SECTIONS:
+            section = InspectionSections(
+                template_id=template.id,
+                name=section_name,
+                display_order=order,
+            )
+            db.session.add(section)
+            db.session.flush()
+
+            for i, label in enumerate(items, 1):
+                item = InspectionItems(
+                    section_id=section.id,
+                    label=label,
+                    display_order=i,
+                )
+                db.session.add(item)
+
+        db.session.commit()
+        print(f'Seeded template "{template.name}" (ID {template.id})')
+        for s in template.sections:
+            print(f'  {s.name}: {len(s.items)} items')
+
+
+if __name__ == '__main__':
+    seed()


### PR DESCRIPTION
## Summary
- Adds 5 new models (InspectionTemplates / Sections / Items / Inspections / InspectionResults)
- Adds 6 endpoints under `/inspections` (checklist, submit, latest, history, by id, templates)
- Adds seed script `seed_inspections.py` loading a 6-section / 33-item Truck Pre-Trip template
- Adds `skipped` boolean on Inspections so leadership can track who bypassed the inspection via the X button

## Test plan
- [ ] `flask run --host=0.0.0.0` and hit `GET /inspections/checklist` with a contractor JWT → returns active template + sections + items
- [ ] `POST /inspections/submit` with `no_issues_found: true` → creates Inspection with status `passed` and all items marked passed
- [ ] `POST /inspections/submit` with per-item results → status reflects pass/fail
- [ ] `POST /inspections/submit` with `skipped: true` → creates Inspection with status `skipped`, no results rows
- [ ] `GET /inspections/latest` returns the most recent for the logged-in contractor
