### PR TITLE
Revert login-gate; add dev button on Home for Inspection demo

### DIFF
--- a/frontend/field-force-contractor/screens/BiometricScreen.tsx
+++ b/frontend/field-force-contractor/screens/BiometricScreen.tsx
@@ -22,7 +22,7 @@
 //    const result = await LocalAuthentication.authenticateAsync({
 //      promptMessage: 'Verify your identity',
 //    });
-//    if (result.success) { navigation.replace('Inspection'); }
+//    if (result.success) { navigation.replace('Dashboard'); }
 //    else { setScanState('failed'); }
 //
 // ──────────────────────────────────────────────────────────────────────────────
@@ -90,14 +90,14 @@ export default function BiometricScreen() {
       if (DEV_MODE) {
         // DEV MODE: always succeed so the full flow can be tested.
         // Use "Force Fail (Dev)" button to test the failure/PIN path.
-        navigation.replace('Inspection');
+        navigation.replace('Dashboard');
         return;
       }
 
       // PRODUCTION: replace with real LocalAuthentication — see dev note above
       const scanWorked = Math.random() > 0.3;
       if (scanWorked) {
-        navigation.replace('Inspection');
+        navigation.replace('Dashboard');
       } else {
         setScanState('failed');
       }

--- a/frontend/field-force-contractor/screens/HomeScreen.tsx
+++ b/frontend/field-force-contractor/screens/HomeScreen.tsx
@@ -1,7 +1,12 @@
 import { useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../App';
 import { MainFrame } from '../components/MainFrame';
+
+type Nav = NativeStackNavigationProp<RootStackParamList, 'Home'>;
 
 type Status = 'driving' | 'work' | 'offline';
 
@@ -24,6 +29,7 @@ const recentActivities = [
 ];
 
 export default function HomeScreen() {
+    const navigation = useNavigation<Nav>();
     const [currentStatus, setCurrentStatus] = useState<Status>('work');
     const [isStatusOpen, setIsStatusOpen] = useState(false);
 
@@ -122,6 +128,19 @@ export default function HomeScreen() {
             <View style={styles.warning}>
                 <Text style={styles.warningText}>Over 11 hours drive time, time for a break</Text>
             </View>
+
+            {/* ── DEV-ONLY: Truck Inspection entry point ─────────────────────
+                Temporary trigger until the real business rule is wired up
+                (inspection should fire when a ticket is accepted — pending
+                Edward / DOT research). Remove once that flow is in place. */}
+            <TouchableOpacity
+                style={styles.devBtn}
+                onPress={() => navigation.navigate('Inspection')}
+                activeOpacity={0.85}
+            >
+                <Ionicons name="construct-outline" size={16} color="#f59e0b" />
+                <Text style={styles.devBtnText}>Open Truck Inspection (Dev)</Text>
+            </TouchableOpacity>
 
         </MainFrame>
     );
@@ -286,6 +305,28 @@ const styles = StyleSheet.create({
         fontSize: 13,
         fontFamily: 'poppins-bold',
         textAlign: 'center',
+    },
+
+    // Dev-only entry point to Truck Inspection — remove when the real
+    // trigger (ticket accepted) is wired up.
+    devBtn: {
+        width: '90%',
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 8,
+        paddingVertical: 12,
+        paddingHorizontal: 16,
+        borderRadius: 12,
+        borderWidth: 1,
+        borderColor: '#f59e0b',
+        backgroundColor: 'rgba(245,158,11,0.08)',
+        marginBottom: 24,
+    },
+    devBtnText: {
+        color: '#f59e0b',
+        fontSize: 13,
+        fontFamily: 'poppins-bold',
     },
 
 });

--- a/frontend/field-force-contractor/screens/InspectionScreen.tsx
+++ b/frontend/field-force-contractor/screens/InspectionScreen.tsx
@@ -66,33 +66,16 @@ export default function InspectionScreen() {
   const [isSubmitting,  setIsSubmitting]   = useState(false);
   const [submitError,   setSubmitError]    = useState('');
 
-  // On mount:
-  //   1. Check if today's inspection is already done (submitted, no-issues,
-  //      or skipped). If so → forward straight to Home. This is what makes
-  //      the screen a "gate" — it only blocks the first login of the day.
-  //   2. Otherwise load the checklist template for display.
+  // On mount: load the checklist template.
+  //
+  // NOTE (demo mode): The same-day "already inspected → skip to Home" gate
+  // was removed per team discussion. The real trigger for the inspection
+  // flow is still pending (Jonathan / Edward — expected to fire when a
+  // contractor accepts a ticket, not at login). Until that wiring lands,
+  // the screen is reached via the dev button on HomeScreen and should
+  // ALWAYS render the checklist so stakeholders see the full flow.
   useEffect(() => {
     const run = async () => {
-      // Step 1 — inspection gate
-      try {
-        const latest = await api.authGet<{ submitted_at?: string; created_at?: string }>(
-          '/inspections/latest',
-        );
-        const when = latest.submitted_at ?? latest.created_at;
-        if (when) {
-          const sameDay =
-            new Date(when).toDateString() === new Date().toDateString();
-          if (sameDay) {
-            navigation.replace('Home');
-            return;
-          }
-        }
-      } catch (err) {
-        // 404 = no inspections yet. Any other failure: let the user try the
-        // checklist flow — the submit call will surface any real API issue.
-      }
-
-      // Step 2 — load the checklist template
       try {
         const data = await api.authGet<ChecklistTemplate>('/inspections/checklist');
         setTemplate(data);

--- a/frontend/field-force-contractor/screens/OfflineLoginScreen.tsx
+++ b/frontend/field-force-contractor/screens/OfflineLoginScreen.tsx
@@ -91,7 +91,7 @@ export default function OfflineLoginScreen() {
     }
     // ─────────────────────────────────────────────────────────────────────
 
-    navigation.replace('Inspection');
+    navigation.replace('Dashboard');
   };
 
   return (


### PR DESCRIPTION
Follow-up to #181. Per Troy + Jonathan: inspection shouldn't gate login.
The real trigger (ticket accepted, per DOT/fleet rules) is still pending
research, so for today's stakeholder demo:

- HomeScreen: add temporary "Open Truck Inspection (Dev)" entry point
- BiometricScreen: success path goes back to Dashboard (Troy's original)
- OfflineLoginScreen: PIN success goes back to Dashboard
- InspectionScreen: drop the same-day /inspections/latest redirect so
  the screen always renders the checklist when opened from the dev button