### PR TITLE
feat: Add Drive Time Tracker screen and backend

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -7,6 +7,7 @@ from .blueprints.field_contractors import field_contractors_bp
 from .blueprints.tickets import tickets_bp
 from .blueprints.work_orders import work_orders_bp
 from .blueprints.inspections import inspections_bp
+from .blueprints.drive_time import drive_time_bp
 
 
 def create_app(config_name):
@@ -25,6 +26,7 @@ def create_app(config_name):
 
     app.register_blueprint(work_orders_bp, url_prefix='/api/work-orders')
     app.register_blueprint(inspections_bp, url_prefix='/inspections')
+    app.register_blueprint(drive_time_bp, url_prefix='/drive-time')
 
 
     return app

--- a/backend/app/blueprints/auth_users/routes.py
+++ b/backend/app/blueprints/auth_users/routes.py
@@ -14,8 +14,28 @@ def login():
         data = login_schema.load(request.json)
     except ValidationError as e:
         return jsonify(e.messages), 400
-    
-    user = db.session.query(Auth_users).where(Auth_users.username==data['username']).first()
+
+    # Frontend sends `identifier` (accepts email OR username); legacy clients
+    # may still send `email` or `username` directly — accept any of the three.
+    identifier = (
+        data.get('identifier')
+        or data.get('email')
+        or data.get('username')
+        or ''
+    ).strip()
+
+    if not identifier:
+        return jsonify({
+            'error': 'Please provide an email address or username.',
+            'code':  'MISSING_IDENTIFIER',
+        }), 400
+
+    # Presence of '@' is a strong enough signal that the contractor typed an
+    # email. Both columns are unique so only one lookup is needed per request.
+    if '@' in identifier:
+        user = db.session.query(Auth_users).where(Auth_users.email == identifier).first()
+    else:
+        user = db.session.query(Auth_users).where(Auth_users.username == identifier).first()
 
     if user and check_password_hash(user.password, data['password']):
         token = encode_token(user.id, user.role)
@@ -24,9 +44,10 @@ def login():
             'token': token,
             'user': auth_user_schema.dump(user)
         }), 200
-    
+
+    # Generic message — don't leak whether the email/username was recognised
     return jsonify({
-        'error': 'Invalid username or password.',
+        'error': 'Invalid credentials.',
         'code':  'INVALID_CREDENTIALS',
     }), 401
 

--- a/backend/app/blueprints/auth_users/schemas.py
+++ b/backend/app/blueprints/auth_users/schemas.py
@@ -9,7 +9,14 @@ class AuthUserSchema(ma.SQLAlchemyAutoSchema):
         include_fk = True
 
 class LoginSchema(Schema):
-    username = fields.Str(required=True)
+    # `identifier` is the preferred field — the frontend sends whatever the
+    # contractor typed (username OR email) and the route handler decides
+    # which column to look up. `username` and `email` are kept for backward
+    # compatibility with older clients / test scripts; at least one of the
+    # three must be present, validated in the route.
+    identifier = fields.Str(required=False)
+    username = fields.Str(required=False)
+    email = fields.Str(required=False)
     password = fields.Str(required=True)
 
 class AuthUserUpdateSchema(Schema):

--- a/backend/app/blueprints/drive_time/__init__.py
+++ b/backend/app/blueprints/drive_time/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+drive_time_bp = Blueprint('drive_time_bp', __name__)
+
+from . import routes

--- a/backend/app/blueprints/drive_time/routes.py
+++ b/backend/app/blueprints/drive_time/routes.py
@@ -9,6 +9,13 @@ from datetime import datetime, timezone, date, timedelta
 
 VALID_STATUSES = {'driving', 'on_duty', 'off_duty', 'sleeper_berth'}
 
+
+def _ensure_utc(dt):
+    """SQLite returns naive datetimes — attach UTC tzinfo if missing."""
+    if dt is None:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
 # FMCSA limits (in seconds)
 DAILY_DRIVE_LIMIT = 11 * 3600       # 11 hours driving per day
 DAILY_ON_DUTY_LIMIT = 14 * 3600     # 14-hour on-duty window
@@ -24,10 +31,7 @@ def _total_driving_seconds(session):
             if log.duration_seconds is not None:
                 total += log.duration_seconds
             elif log.end_time is None:
-                # Currently driving — count elapsed time
-                # SQLite returns naive datetimes, so attach UTC if missing
-                start = log.start_time if log.start_time.tzinfo else log.start_time.replace(tzinfo=timezone.utc)
-                total += int((now - start).total_seconds())
+                total += int((now - _ensure_utc(log.start_time)).total_seconds())
     return total
 
 
@@ -110,7 +114,7 @@ def change_status():
     now = datetime.now(timezone.utc)
     session = _get_or_create_session(contractor_id)
 
-    if session.current_status == new_status:
+    if session.current_status == new_status and session.is_active:
         return jsonify({'error': f'Already in {new_status} status.'}), 400
 
     # Close the current active log (if any)
@@ -122,7 +126,7 @@ def change_status():
 
     if active_log:
         active_log.end_time = now
-        active_log.duration_seconds = int((now - active_log.start_time).total_seconds())
+        active_log.duration_seconds = int((now - _ensure_utc(active_log.start_time)).total_seconds())
 
     # Create a new log for the new status
     new_log = DutyLogs(
@@ -172,7 +176,7 @@ def stop_session():
 
     if active_log:
         active_log.end_time = now
-        active_log.duration_seconds = int((now - active_log.start_time).total_seconds())
+        active_log.duration_seconds = int((now - _ensure_utc(active_log.start_time)).total_seconds())
 
     session.is_active = False
     session.ended_at = now

--- a/backend/app/blueprints/drive_time/routes.py
+++ b/backend/app/blueprints/drive_time/routes.py
@@ -1,0 +1,205 @@
+from flask import request, jsonify
+from app.models import DutySessions, DutyLogs, db
+from .schemas import duty_session_schema, duty_logs_schema, status_change_schema
+from marshmallow import ValidationError
+from . import drive_time_bp
+from app.util.auth import token_required
+from datetime import datetime, timezone, date, timedelta
+
+
+VALID_STATUSES = {'driving', 'on_duty', 'off_duty', 'sleeper_berth'}
+
+# FMCSA limits (in seconds)
+DAILY_DRIVE_LIMIT = 11 * 3600       # 11 hours driving per day
+DAILY_ON_DUTY_LIMIT = 14 * 3600     # 14-hour on-duty window
+CYCLE_LIMIT = 70 * 3600             # 70-hour / 8-day cycle
+
+
+def _total_driving_seconds(session):
+    """Sum all driving seconds for a session, including the active segment."""
+    total = 0
+    now = datetime.now(timezone.utc)
+    for log in session.logs:
+        if log.status == 'driving':
+            if log.duration_seconds is not None:
+                total += log.duration_seconds
+            elif log.end_time is None:
+                # Currently driving — count elapsed time
+                # SQLite returns naive datetimes, so attach UTC if missing
+                start = log.start_time if log.start_time.tzinfo else log.start_time.replace(tzinfo=timezone.utc)
+                total += int((now - start).total_seconds())
+    return total
+
+
+def _get_or_create_session(contractor_id):
+    """Return today's active session, or create a new one."""
+    today = date.today()
+    session = db.session.query(DutySessions).filter_by(
+        contractor_id=contractor_id,
+        session_date=today,
+        is_active=True,
+    ).first()
+
+    if not session:
+        session = DutySessions(
+            contractor_id=contractor_id,
+            session_date=today,
+            current_status='off_duty',
+        )
+        db.session.add(session)
+        db.session.flush()
+
+    return session
+
+
+# ── GET /drive-time/current — current session + logs ────────────────────────
+@drive_time_bp.route('/current', methods=['GET'])
+@token_required
+def get_current_session():
+    contractor_id = request.user_id
+    today = date.today()
+
+    session = db.session.query(DutySessions).filter_by(
+        contractor_id=contractor_id,
+        session_date=today,
+        is_active=True,
+    ).first()
+
+    if not session:
+        return jsonify({
+            'session': None,
+            'driving_seconds': 0,
+            'remaining_seconds': DAILY_DRIVE_LIMIT,
+            'cycle_seconds': 0,
+        }), 200
+
+    driving_secs = _total_driving_seconds(session)
+
+    # 70-hour cycle: sum driving across last 8 days
+    eight_days_ago = today - timedelta(days=7)
+    cycle_sessions = db.session.query(DutySessions).filter(
+        DutySessions.contractor_id == contractor_id,
+        DutySessions.session_date >= eight_days_ago,
+    ).all()
+    cycle_secs = sum(_total_driving_seconds(s) for s in cycle_sessions)
+
+    return jsonify({
+        'session': duty_session_schema.dump(session),
+        'driving_seconds': driving_secs,
+        'remaining_seconds': max(0, DAILY_DRIVE_LIMIT - driving_secs),
+        'cycle_seconds': cycle_secs,
+    }), 200
+
+
+# ── POST /drive-time/status — change duty status ───────────────────────────
+@drive_time_bp.route('/status', methods=['POST'])
+@token_required
+def change_status():
+    try:
+        data = status_change_schema.load(request.json)
+    except ValidationError as e:
+        return jsonify(e.messages), 400
+
+    new_status = data['status']
+    if new_status not in VALID_STATUSES:
+        return jsonify({
+            'error': f'Invalid status. Must be one of: {", ".join(sorted(VALID_STATUSES))}',
+        }), 400
+
+    contractor_id = request.user_id
+    now = datetime.now(timezone.utc)
+    session = _get_or_create_session(contractor_id)
+
+    if session.current_status == new_status:
+        return jsonify({'error': f'Already in {new_status} status.'}), 400
+
+    # Close the current active log (if any)
+    active_log = db.session.query(DutyLogs).filter_by(
+        session_id=session.id,
+        contractor_id=contractor_id,
+        end_time=None,
+    ).first()
+
+    if active_log:
+        active_log.end_time = now
+        active_log.duration_seconds = int((now - active_log.start_time).total_seconds())
+
+    # Create a new log for the new status
+    new_log = DutyLogs(
+        session_id=session.id,
+        contractor_id=contractor_id,
+        status=new_status,
+        start_time=now,
+    )
+    db.session.add(new_log)
+
+    session.current_status = new_status
+    db.session.commit()
+
+    driving_secs = _total_driving_seconds(session)
+
+    return jsonify({
+        'message': f'Status changed to {new_status}.',
+        'session': duty_session_schema.dump(session),
+        'driving_seconds': driving_secs,
+        'remaining_seconds': max(0, DAILY_DRIVE_LIMIT - driving_secs),
+    }), 200
+
+
+# ── POST /drive-time/stop — end the session for the day ─────────────────────
+@drive_time_bp.route('/stop', methods=['POST'])
+@token_required
+def stop_session():
+    contractor_id = request.user_id
+    today = date.today()
+    now = datetime.now(timezone.utc)
+
+    session = db.session.query(DutySessions).filter_by(
+        contractor_id=contractor_id,
+        session_date=today,
+        is_active=True,
+    ).first()
+
+    if not session:
+        return jsonify({'error': 'No active session to stop.'}), 404
+
+    # Close any open log
+    active_log = db.session.query(DutyLogs).filter_by(
+        session_id=session.id,
+        contractor_id=contractor_id,
+        end_time=None,
+    ).first()
+
+    if active_log:
+        active_log.end_time = now
+        active_log.duration_seconds = int((now - active_log.start_time).total_seconds())
+
+    session.is_active = False
+    session.ended_at = now
+    session.current_status = 'off_duty'
+    db.session.commit()
+
+    return jsonify({
+        'message': 'Session ended.',
+        'session': duty_session_schema.dump(session),
+    }), 200
+
+
+# ── GET /drive-time/logs — driving log history for today ────────────────────
+@drive_time_bp.route('/logs', methods=['GET'])
+@token_required
+def get_logs():
+    contractor_id = request.user_id
+    today = date.today()
+
+    session = db.session.query(DutySessions).filter_by(
+        contractor_id=contractor_id,
+        session_date=today,
+    ).first()
+
+    if not session:
+        return jsonify({'logs': []}), 200
+
+    return jsonify({
+        'logs': duty_logs_schema.dump(session.logs),
+    }), 200

--- a/backend/app/blueprints/drive_time/routes.py
+++ b/backend/app/blueprints/drive_time/routes.py
@@ -7,8 +7,6 @@ from app.util.auth import token_required
 from datetime import datetime, timezone, date, timedelta
 
 
-VALID_STATUSES = {'driving', 'on_duty', 'off_duty', 'sleeper_berth'}
-
 
 def _ensure_utc(dt):
     """SQLite returns naive datetimes — attach UTC tzinfo if missing."""
@@ -105,13 +103,12 @@ def change_status():
         return jsonify(e.messages), 400
 
     new_status = data['status']
-    if new_status not in VALID_STATUSES:
-        return jsonify({
-            'error': f'Invalid status. Must be one of: {", ".join(sorted(VALID_STATUSES))}',
-        }), 400
-
     contractor_id = request.user_id
-    now = datetime.now(timezone.utc)
+
+    # Use client-supplied timestamp when available (offline sync support),
+    # otherwise fall back to the current server time.
+    now = data['timestamp'] or datetime.now(timezone.utc)
+
     session = _get_or_create_session(contractor_id)
 
     if session.current_status == new_status and session.is_active:

--- a/backend/app/blueprints/drive_time/schemas.py
+++ b/backend/app/blueprints/drive_time/schemas.py
@@ -1,0 +1,28 @@
+from app.extensions import ma
+from app.models import DutySessions, DutyLogs
+from marshmallow import fields, Schema
+
+
+class DutyLogSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = DutyLogs
+        include_fk = True
+
+
+class DutySessionSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = DutySessions
+        include_fk = True
+
+    logs = fields.Nested(DutyLogSchema, many=True, dump_only=True)
+
+
+class StatusChangeSchema(Schema):
+    """Payload for POST /drive-time/status — change the contractor's duty status."""
+    status = fields.Str(required=True)  # driving, on_duty, off_duty, sleeper_berth
+
+
+duty_log_schema = DutyLogSchema()
+duty_logs_schema = DutyLogSchema(many=True)
+duty_session_schema = DutySessionSchema()
+status_change_schema = StatusChangeSchema()

--- a/backend/app/blueprints/drive_time/schemas.py
+++ b/backend/app/blueprints/drive_time/schemas.py
@@ -1,6 +1,6 @@
 from app.extensions import ma
 from app.models import DutySessions, DutyLogs
-from marshmallow import fields, Schema
+from marshmallow import fields, Schema, validate
 
 
 class DutyLogSchema(ma.SQLAlchemyAutoSchema):
@@ -18,8 +18,23 @@ class DutySessionSchema(ma.SQLAlchemyAutoSchema):
 
 
 class StatusChangeSchema(Schema):
-    """Payload for POST /drive-time/status — change the contractor's duty status."""
-    status = fields.Str(required=True)  # driving, on_duty, off_duty, sleeper_berth
+    """Payload for POST /drive-time/status — change the contractor's duty status.
+
+    Fields:
+        status    — required, must be one of the four FMCSA duty statuses.
+        timestamp — optional ISO-8601 UTC string supplied by the frontend.
+                    Use this when syncing offline status changes so the real
+                    event time is preserved instead of the server's receive time.
+                    Falls back to datetime.now(UTC) on the server if omitted.
+    """
+    status = fields.Str(
+        required=True,
+        validate=validate.OneOf(["driving", "on_duty", "off_duty", "sleeper_berth"]),
+    )
+    timestamp = fields.DateTime(
+        load_default=None,
+        metadata={"description": "Client-side event time (UTC). Omit to use server time."},
+    )
 
 
 duty_log_schema = DutyLogSchema()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -171,6 +171,43 @@ class InspectionResults(Base):
     item = relationship("InspectionItems")
 
 
+# ── Drive Time / Hours of Service models ──────────────────────────────────────
+# FMCSA-style duty status tracking. A DutySession represents a shift (from
+# first status change to end-of-day). DutyLogs are the individual segments
+# within that session (driving, on-duty, off-duty, sleeper-berth).
+
+class DutySessions(Base):
+    """A contractor's duty session for a given day / shift."""
+    __tablename__ = 'duty_sessions'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    contractor_id: Mapped[int] = mapped_column(ForeignKey('contractors.id'), nullable=False)
+    current_status: Mapped[str] = mapped_column(String(20), nullable=False, default='off_duty')  # driving, on_duty, off_duty, sleeper_berth
+    session_date: Mapped[date] = mapped_column(Date, nullable=False)
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now(timezone.utc), nullable=False)
+    ended_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now(timezone.utc), nullable=False)
+
+    logs = relationship("DutyLogs", back_populates="session", order_by="DutyLogs.start_time")
+
+
+class DutyLogs(Base):
+    """A single duty segment within a session (e.g. 6:30 AM–10:15 AM Driving)."""
+    __tablename__ = 'duty_logs'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    session_id: Mapped[int] = mapped_column(ForeignKey('duty_sessions.id'), nullable=False)
+    contractor_id: Mapped[int] = mapped_column(ForeignKey('contractors.id'), nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False)  # driving, on_duty, off_duty, sleeper_berth
+    start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    end_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=True)  # null = currently active
+    duration_seconds: Mapped[int] = mapped_column(Integer, nullable=True)  # computed when end_time is set
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now(timezone.utc), nullable=False)
+
+    session = relationship("DutySessions", back_populates="logs")
+
+
 class Vendors(Base):
     __tablename__ = 'vendors'
 

--- a/frontend/field-force-contractor/App.tsx
+++ b/frontend/field-force-contractor/App.tsx
@@ -15,6 +15,7 @@ import {Chat} from "./screens/ChatScreen";
 import TicketsScreen from "./screens/TicketsScreen";
 import TicketDetailScreen from "./screens/TicketDetailScreen";
 import InspectionScreen from "./screens/InspectionScreen";
+import DriveTimeTrackerScreen from "./screens/DriveTimeTrackerScreen";
  
 // ── TROY — Auth screens ──────────────────────────────────────
 import LoginScreen           from "./screens/LoginScreen";
@@ -56,6 +57,9 @@ export type RootStackParamList = {
 
   // ── Aldo — Inspection screen ──────────────────────────────────
   Inspection:      undefined;
+
+  // ── Aldo — Drive Time Tracker ────────────────────────────────
+  DriveTimeTracker: undefined;
 
   // ── Charlie — Dashboard (placeholder until real screen is built) ──
   Dashboard:       undefined;
@@ -102,7 +106,8 @@ export default function App() {
       <StackNavigator.Screen name="LicenseDetails" component={LicenseScreen} />
       <StackNavigator.Screen name="Tickets"        component={TicketsScreen} />
       <StackNavigator.Screen name="TicketDetail"   component={TicketDetailScreen} />
-      <StackNavigator.Screen name="Inspection"     component={InspectionScreen} />
+      <StackNavigator.Screen name="Inspection"       component={InspectionScreen} />
+      <StackNavigator.Screen name="DriveTimeTracker" component={DriveTimeTrackerScreen} />
 
 
     </StackNavigator.Navigator>

--- a/frontend/field-force-contractor/App.tsx
+++ b/frontend/field-force-contractor/App.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
+import { View, ActivityIndicator } from "react-native";
 import { LoadFonts } from "./utils/LoadFonts";
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { AuthProvider } from './contexts/AuthContext';
-
+import { AuthProvider, useAuth } from './contexts/AuthContext';
 
 // ── Jonathan ──────────────────────────────────────
-import {Blank} from "./screens/Blank"; //Test playground page will be removed for development purpose only!
+import {Blank} from "./screens/Blank";
 import HomeScreen from "./screens/HomeScreen"
 import {screenConfig} from "./constants/ScreenConfig";
 import { Contacts } from "./screens/ContactScreen";
@@ -16,18 +16,18 @@ import TicketsScreen from "./screens/TicketsScreen";
 import TicketDetailScreen from "./screens/TicketDetailScreen";
 import InspectionScreen from "./screens/InspectionScreen";
 import DriveTimeTrackerScreen from "./screens/DriveTimeTrackerScreen";
- 
+
 // ── TROY — Auth screens ──────────────────────────────────────
 import LoginScreen           from "./screens/LoginScreen";
 import OfflineLoginScreen    from "./screens/OfflineLoginScreen";
 import BiometricScreen       from "./screens/BiometricScreen";
 import PasswordResetScreen   from "./screens/PasswordResetScreen";
 import OfflinePinResetScreen from "./screens/OfflinePinResetScreen";
- 
+
 // ── TROY — Profile screens ───────────────────────────────────
 import ProfileScreen from "./screens/ProfileScreen";
 import LicenseScreen from "./screens/LicenseScreen";
- 
+
 export type RootStackParamList = {
   // ── Jonathan — App screens ───────────────────────────────────
   SplashScreen:  undefined;
@@ -37,11 +37,11 @@ export type RootStackParamList = {
   Contacts:      undefined;
   Chat:          undefined;
   Tickets:       undefined;
-  TicketDetail: { taskId: number };
+  TicketDetail:  { taskId: number };
 
   // ── Jonathan — Work Orders (placeholder until real screen built) ──
   JobDetail:     { jobId: string; workOrderId: string };
-  // ── Charlie — Work Orders (placeholder until real screen built) ──  
+  // ── Charlie — Work Orders (placeholder until real screen built) ──
   WorkOrders:    undefined;
 
   // ── Troy — Auth screens ──────────────────────────────────────
@@ -66,53 +66,79 @@ export type RootStackParamList = {
 };
 
 const StackNavigator = createNativeStackNavigator();
-        
+
+// ── Auth-aware navigator ───────────────────────────────────────────────────
+// Renders the Auth stack (Login flow) when there is no valid token.
+// Renders the App stack (Inspection gate → Dashboard) when authenticated.
+// React Navigation automatically transitions between stacks when isAuthenticated changes.
+function RootNavigator() {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  // Still reading token from SecureStore — show a branded loading screen
+  if (isLoading) {
+    return (
+      <View style={{ flex: 1, backgroundColor: '#0a0a0a', alignItems: 'center', justifyContent: 'center' }}>
+        <ActivityIndicator size="large" color="#3b82f6" />
+      </View>
+    );
+  }
+
+  return (
+    <StackNavigator.Navigator screenOptions={screenConfig.window}>
+      {isAuthenticated ? (
+        // ── Protected App screens ─────────────────────────────────────────
+        // First screen is Inspection — the daily gate. After passing (or skipping)
+        // it navigates to Dashboard. All other app screens follow.
+        <>
+          <StackNavigator.Screen name="Inspection"       component={InspectionScreen}       />
+          <StackNavigator.Screen name="Dashboard"        component={HomeScreen}              />
+          <StackNavigator.Screen name="Home"             component={HomeScreen}              />
+          <StackNavigator.Screen name="Blank"            component={Blank}                  />
+          <StackNavigator.Screen name="Contacts"         component={Contacts}               />
+          <StackNavigator.Screen name="Chat"             component={Chat}                   />
+          <StackNavigator.Screen name="Tickets"          component={TicketsScreen}          />
+          <StackNavigator.Screen name="TicketDetail"     component={TicketDetailScreen}     />
+          <StackNavigator.Screen name="Profile"          component={ProfileScreen}          />
+          <StackNavigator.Screen name="LicenseDetails"   component={LicenseScreen}          />
+          <StackNavigator.Screen name="DriveTimeTracker" component={DriveTimeTrackerScreen} />
+          {/* SplashScreen kept for Jonathan's direct nav references */}
+          <StackNavigator.Screen name="SplashScreen"     component={SplashScreen}           />
+        </>
+      ) : (
+        // ── Public Auth screens ───────────────────────────────────────────
+        // Login is the entry point. After a successful login() call the auth
+        // state flips and React Navigation auto-routes to Inspection above.
+        <>
+          <StackNavigator.Screen name="Login"           component={LoginScreen}           />
+          <StackNavigator.Screen name="OfflineLogin"    component={OfflineLoginScreen}    />
+          <StackNavigator.Screen name="BiometricCheck"  component={BiometricScreen}       />
+          <StackNavigator.Screen name="PasswordReset"   component={PasswordResetScreen}   />
+          <StackNavigator.Screen name="OfflinePinReset" component={OfflinePinResetScreen} />
+        </>
+      )}
+    </StackNavigator.Navigator>
+  );
+}
+
+// ── App root ───────────────────────────────────────────────────────────────
 export default function App() {
-  // ── Jonathan — Import External Fonts ───────────────────────────────────
-  // Loads custom fonts when the app starts, then updates state so the app only renders after the fonts are ready.
   const [externalFontsLoaded, setExternalFontsLoaded] = useState(false);
+
   useEffect(() => {
     const load = async () => {
-      let isLoaded = await LoadFonts();
+      const isLoaded = await LoadFonts();
       setExternalFontsLoaded(isLoaded);
     };
     load();
   }, []);
- 
+
+  if (!externalFontsLoaded) return null;
+
   return (
-   (externalFontsLoaded) &&
-  <AuthProvider>
-  <NavigationContainer>
-
-    <StackNavigator.Navigator screenOptions={screenConfig.window} initialRouteName="SplashScreen">
-      {/* Jonathan */}
-      <StackNavigator.Screen name="SplashScreen"  component={SplashScreen}/>
-      <StackNavigator.Screen name="Blank" component={Blank}/>
-      <StackNavigator.Screen name="Contacts" component={Contacts}/>
-      <StackNavigator.Screen name="Chat" component={Chat} />
-      
-
-      {/* Charlie */}
-      <StackNavigator.Screen name="Home" component={HomeScreen}/>
-      <StackNavigator.Screen name="Dashboard" component={HomeScreen}/>
-
-      {/* Troy */}
-      <StackNavigator.Screen name="Login"           component={LoginScreen}           />
-      <StackNavigator.Screen name="OfflineLogin"    component={OfflineLoginScreen}    />
-      <StackNavigator.Screen name="BiometricCheck"  component={BiometricScreen}       />
-      <StackNavigator.Screen name="PasswordReset"   component={PasswordResetScreen}   />
-      <StackNavigator.Screen name="OfflinePinReset" component={OfflinePinResetScreen} />
-      <StackNavigator.Screen name="Profile"        component={ProfileScreen} />
-      <StackNavigator.Screen name="LicenseDetails" component={LicenseScreen} />
-      <StackNavigator.Screen name="Tickets"        component={TicketsScreen} />
-      <StackNavigator.Screen name="TicketDetail"   component={TicketDetailScreen} />
-      <StackNavigator.Screen name="Inspection"       component={InspectionScreen} />
-      <StackNavigator.Screen name="DriveTimeTracker" component={DriveTimeTrackerScreen} />
-
-
-    </StackNavigator.Navigator>
-
-  </NavigationContainer>
-  </AuthProvider>
+    <AuthProvider>
+      <NavigationContainer>
+        <RootNavigator />
+      </NavigationContainer>
+    </AuthProvider>
   );
 }

--- a/frontend/field-force-contractor/screens/DriveTimeTrackerScreen.tsx
+++ b/frontend/field-force-contractor/screens/DriveTimeTrackerScreen.tsx
@@ -1,0 +1,586 @@
+// DriveTimeTrackerScreen.tsx
+// FMCSA-style drive time tracker. Shows current duty status, live timers,
+// progress bar, and a driving log table. Contractors can toggle between
+// On Duty, Driving, Off Duty, and Sleeper Berth statuses.
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+  ScrollView,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../App';
+import { MainFrame } from '../components/MainFrame';
+import { api, ApiError } from '../utils/api';
+
+type Nav = NativeStackNavigationProp<RootStackParamList, 'DriveTimeTracker'>;
+
+// ── Types matching backend response ────────────────────────────────────────
+
+type DutyLog = {
+  id: number;
+  status: string;
+  start_time: string;
+  end_time: string | null;
+  duration_seconds: number | null;
+};
+
+type DutySession = {
+  id: number;
+  contractor_id: number;
+  current_status: string;
+  session_date: string;
+  is_active: boolean;
+  logs: DutyLog[];
+};
+
+type SessionResponse = {
+  session: DutySession | null;
+  driving_seconds: number;
+  remaining_seconds: number;
+  cycle_seconds: number;
+};
+
+type StatusResponse = {
+  message: string;
+  session: DutySession;
+  driving_seconds: number;
+  remaining_seconds: number;
+};
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const BLUE       = '#3b82f6';
+const RED        = '#ef4444';
+const GREEN      = '#22c55e';
+const ORANGE     = '#ff8c00';
+const DARK_BG    = 'rgba(255,255,255,0.08)';
+const CARD_BG    = 'rgba(255,255,255,0.06)';
+const BORDER     = 'rgba(255,255,255,0.12)';
+const MAX_DRIVE  = 11 * 3600;   // 11-hour daily driving limit
+const CYCLE_MAX  = 70 * 3600;   // 70-hour / 8-day cycle
+
+type DutyStatus = 'on_duty' | 'driving' | 'off_duty' | 'sleeper_berth';
+
+const STATUS_CONFIG: Record<DutyStatus, { label: string; color: string }> = {
+  on_duty:       { label: 'On Duty',      color: BLUE },
+  driving:       { label: 'Driving',      color: GREEN },
+  off_duty:      { label: 'Off Duty',     color: ORANGE },
+  sleeper_berth: { label: 'Sleep Berth',  color: '#8b5cf6' },
+};
+
+const STATUS_ORDER: DutyStatus[] = ['on_duty', 'driving', 'off_duty', 'sleeper_berth'];
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function formatHMS(totalSeconds: number): string {
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+function formatTime12(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
+}
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+function statusLabel(status: string): string {
+  return STATUS_CONFIG[status as DutyStatus]?.label ?? status;
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export default function DriveTimeTrackerScreen() {
+  const navigation = useNavigation<Nav>();
+
+  const [session, setSession]           = useState<DutySession | null>(null);
+  const [drivingSecs, setDrivingSecs]   = useState(0);
+  const [remainingSecs, setRemainingSecs] = useState(MAX_DRIVE);
+  const [cycleSecs, setCycleSecs]       = useState(0);
+  const [loading, setLoading]           = useState(true);
+  const [error, setError]               = useState('');
+  const [changing, setChanging]         = useState(false);
+
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Fetch current session on mount
+  const fetchSession = useCallback(async () => {
+    try {
+      const data = await api.authGet<SessionResponse>('/drive-time/current');
+      setSession(data.session);
+      setDrivingSecs(data.driving_seconds);
+      setRemainingSecs(data.remaining_seconds);
+      setCycleSecs(data.cycle_seconds);
+    } catch (err) {
+      const apiErr = err as ApiError;
+      setError(apiErr.error || 'Failed to load drive time data.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSession();
+  }, [fetchSession]);
+
+  // Live ticker — increments driving seconds every second when status is driving
+  useEffect(() => {
+    if (timerRef.current) clearInterval(timerRef.current);
+
+    if (session?.current_status === 'driving' && session.is_active) {
+      timerRef.current = setInterval(() => {
+        setDrivingSecs(prev => prev + 1);
+        setRemainingSecs(prev => Math.max(0, prev - 1));
+        setCycleSecs(prev => prev + 1);
+      }, 1000);
+    }
+
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [session?.current_status, session?.is_active]);
+
+  // Change duty status
+  const changeStatus = async (newStatus: DutyStatus) => {
+    if (changing) return;
+    if (session?.current_status === newStatus) return;
+
+    setChanging(true);
+    setError('');
+
+    try {
+      const data = await api.authPost<StatusResponse>('/drive-time/status', {
+        status: newStatus,
+      });
+      setSession(data.session);
+      setDrivingSecs(data.driving_seconds);
+      setRemainingSecs(data.remaining_seconds);
+    } catch (err) {
+      const apiErr = err as ApiError;
+      setError(apiErr.error || 'Failed to change status.');
+    } finally {
+      setChanging(false);
+    }
+  };
+
+  // Stop session
+  const stopSession = async () => {
+    if (changing) return;
+    setChanging(true);
+    setError('');
+
+    try {
+      await api.authPost('/drive-time/stop', {});
+      // Refresh to get final state
+      await fetchSession();
+    } catch (err) {
+      const apiErr = err as ApiError;
+      setError(apiErr.error || 'Failed to stop session.');
+    } finally {
+      setChanging(false);
+    }
+  };
+
+  // Progress bar percentage (0–1) based on 11-hour driving limit
+  const progressPct = Math.min(1, drivingSecs / MAX_DRIVE);
+
+  // ── Loading ──────────────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <MainFrame header="default" headerMenu={["none"]} footerMenu={["none"]}>
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color={BLUE} />
+          <Text style={styles.loadingText}>Loading drive time...</Text>
+        </View>
+      </MainFrame>
+    );
+  }
+
+  const currentStatus = (session?.current_status ?? 'off_duty') as DutyStatus;
+  const isActive = session?.is_active ?? false;
+  const logs = session?.logs ?? [];
+
+  return (
+    <MainFrame>
+
+      {/* ── Header ─────────────────────────────────────────────── */}
+      <View style={styles.headerBlock}>
+        <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
+          <Ionicons name="chevron-back" size={24} color="white" />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Drive Time Tracker</Text>
+      </View>
+
+      {/* ── Status buttons ─────────────────────────────────────── */}
+      <View style={styles.statusRow}>
+        {STATUS_ORDER.map(status => {
+          const cfg = STATUS_CONFIG[status];
+          const isSelected = currentStatus === status;
+          return (
+            <TouchableOpacity
+              key={status}
+              style={[
+                styles.statusBtn,
+                { borderColor: cfg.color },
+                isSelected && { backgroundColor: cfg.color },
+              ]}
+              onPress={() => changeStatus(status)}
+              disabled={changing || !isActive}
+              activeOpacity={0.7}
+            >
+              <Text style={[
+                styles.statusBtnText,
+                { color: isSelected ? 'white' : cfg.color },
+              ]}>
+                {cfg.label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+
+      {/* ── Time counters ──────────────────────────────────────── */}
+      <View style={styles.timersRow}>
+        <View style={styles.timerBlock}>
+          <Text style={styles.timerLabel}>Current Drive Time</Text>
+          <Text style={styles.timerValue}>{formatHMS(drivingSecs)}</Text>
+        </View>
+        <View style={styles.timerBlock}>
+          <Text style={styles.timerLabel}>Time Remaining</Text>
+          <Text style={styles.timerValue}>{formatHMS(remainingSecs)}</Text>
+        </View>
+        <View style={styles.timerBlock}>
+          <Text style={styles.timerLabel}>70 Hour</Text>
+          <Text style={styles.timerValue}>{formatHMS(cycleSecs)}</Text>
+        </View>
+      </View>
+
+      {/* ── Progress bar ───────────────────────────────────────── */}
+      <View style={styles.progressCard}>
+        <Text style={styles.progressTitle}>Driving Time Progress</Text>
+
+        {/* Hour markers */}
+        <View style={styles.hourMarkersRow}>
+          {[0, 4, 8, 12, 15].map(h => (
+            <Text key={h} style={styles.hourMarker}>{h}h</Text>
+          ))}
+        </View>
+
+        {/* Bar */}
+        <View style={styles.progressBarBg}>
+          <View style={[
+            styles.progressBarFill,
+            {
+              width: `${progressPct * 100}%`,
+              backgroundColor: progressPct > 0.9 ? RED : ORANGE,
+            },
+          ]} />
+          {/* Truck icon at the progress tip */}
+          <View style={[styles.progressIcon, { left: `${Math.min(progressPct * 100, 95)}%` }]}>
+            <Ionicons name="bus" size={16} color="white" />
+          </View>
+        </View>
+
+        <Text style={styles.progressSubtext}>
+          {formatHMS(drivingSecs)} / {formatHMS(MAX_DRIVE)} max
+        </Text>
+      </View>
+
+      {/* ── Driving Log table ──────────────────────────────────── */}
+      <View style={styles.logCard}>
+        <Text style={styles.logTitle}>Driving Log</Text>
+
+        {/* Table header */}
+        <View style={styles.logHeaderRow}>
+          <Text style={[styles.logHeaderCell, { flex: 1.2 }]}>Start Time</Text>
+          <Text style={[styles.logHeaderCell, { flex: 1.2 }]}>End Time</Text>
+          <Text style={[styles.logHeaderCell, { flex: 1 }]}>Duration</Text>
+          <Text style={[styles.logHeaderCell, { flex: 1 }]}>Status</Text>
+        </View>
+
+        {/* Log rows */}
+        {logs.length === 0 ? (
+          <View style={styles.emptyRow}>
+            <Text style={styles.emptyText}>No logs yet. Change status to start tracking.</Text>
+          </View>
+        ) : (
+          logs.map(log => {
+            const durSecs = log.duration_seconds
+              ?? (log.end_time
+                ? Math.floor((new Date(log.end_time).getTime() - new Date(log.start_time).getTime()) / 1000)
+                : Math.floor((Date.now() - new Date(log.start_time).getTime()) / 1000));
+
+            return (
+              <View key={log.id} style={styles.logRow}>
+                <Text style={[styles.logCell, { flex: 1.2 }]}>
+                  {formatTime12(log.start_time)}
+                </Text>
+                <Text style={[styles.logCell, { flex: 1.2 }]}>
+                  {log.end_time ? formatTime12(log.end_time) : '--'}
+                </Text>
+                <Text style={[styles.logCell, { flex: 1 }]}>
+                  {formatDuration(durSecs)}
+                </Text>
+                <Text style={[styles.logCell, { flex: 1, color: STATUS_CONFIG[log.status as DutyStatus]?.color ?? 'white' }]}>
+                  {statusLabel(log.status)}
+                </Text>
+              </View>
+            );
+          })
+        )}
+      </View>
+
+      {/* ── Error ──────────────────────────────────────────────── */}
+      {error !== '' && (
+        <View style={styles.errorWrap}>
+          <Ionicons name="alert-circle-outline" size={16} color={RED} />
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
+      )}
+
+      {/* ── Stop Driving button ────────────────────────────────── */}
+      <TouchableOpacity
+        style={[styles.stopBtn, !isActive && styles.stopBtnDisabled]}
+        onPress={stopSession}
+        disabled={changing || !isActive}
+        activeOpacity={0.85}
+      >
+        {changing ? (
+          <ActivityIndicator color="white" />
+        ) : (
+          <Text style={styles.stopBtnText}>
+            {isActive ? 'Stop Driving' : 'Session Ended'}
+          </Text>
+        )}
+      </TouchableOpacity>
+
+    </MainFrame>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Styles
+// ─────────────────────────────────────────────────────────────────────────────
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+  },
+  loadingText: { color: '#9ca3af', fontSize: 14, fontFamily: 'poppins-regular' },
+
+  // ── Header ─────────────────────────────────────────────────────────────
+  headerBlock: {
+    width: '90%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 8,
+    marginBottom: 12,
+    gap: 12,
+  },
+  backBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: 'rgba(255,255,255,0.1)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontFamily: 'poppins-bold',
+    color: 'white',
+  },
+
+  // ── Status buttons ─────────────────────────────────────────────────────
+  statusRow: {
+    width: '90%',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    justifyContent: 'center',
+    marginBottom: 16,
+  },
+  statusBtn: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+    borderWidth: 2,
+  },
+  statusBtnText: {
+    fontSize: 13,
+    fontFamily: 'poppins-bold',
+  },
+
+  // ── Timers ─────────────────────────────────────────────────────────────
+  timersRow: {
+    width: '90%',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 16,
+  },
+  timerBlock: {
+    alignItems: 'center',
+    flex: 1,
+  },
+  timerLabel: {
+    fontSize: 11,
+    fontFamily: 'poppins-regular',
+    color: 'rgba(255,255,255,0.6)',
+    marginBottom: 4,
+  },
+  timerValue: {
+    fontSize: 18,
+    fontFamily: 'poppins-bold',
+    color: 'white',
+  },
+
+  // ── Progress ───────────────────────────────────────────────────────────
+  progressCard: {
+    width: '90%',
+    backgroundColor: 'rgba(255,255,255,0.95)',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+  },
+  progressTitle: {
+    fontSize: 14,
+    fontFamily: 'poppins-bold',
+    color: '#1f2937',
+    textAlign: 'center',
+    marginBottom: 12,
+  },
+  hourMarkersRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 6,
+  },
+  hourMarker: {
+    fontSize: 10,
+    fontFamily: 'poppins-regular',
+    color: '#6b7280',
+  },
+  progressBarBg: {
+    width: '100%',
+    height: 12,
+    backgroundColor: '#e5e7eb',
+    borderRadius: 6,
+    overflow: 'visible',
+    position: 'relative',
+  },
+  progressBarFill: {
+    height: '100%',
+    borderRadius: 6,
+  },
+  progressIcon: {
+    position: 'absolute',
+    top: -6,
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: '#374151',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  progressSubtext: {
+    fontSize: 11,
+    fontFamily: 'poppins-regular',
+    color: '#6b7280',
+    textAlign: 'center',
+    marginTop: 8,
+  },
+
+  // ── Log table ──────────────────────────────────────────────────────────
+  logCard: {
+    width: '90%',
+    backgroundColor: 'rgba(255,255,255,0.95)',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+  },
+  logTitle: {
+    fontSize: 14,
+    fontFamily: 'poppins-bold',
+    color: '#1f2937',
+    marginBottom: 12,
+  },
+  logHeaderRow: {
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+    borderBottomColor: '#e5e7eb',
+    paddingBottom: 8,
+    marginBottom: 4,
+  },
+  logHeaderCell: {
+    fontSize: 11,
+    fontFamily: 'poppins-bold',
+    color: '#374151',
+  },
+  logRow: {
+    flexDirection: 'row',
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: '#f3f4f6',
+  },
+  logCell: {
+    fontSize: 12,
+    fontFamily: 'poppins-regular',
+    color: '#1f2937',
+  },
+  emptyRow: {
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+  emptyText: {
+    fontSize: 12,
+    fontFamily: 'poppins-regular',
+    color: '#9ca3af',
+  },
+
+  // ── Error ──────────────────────────────────────────────────────────────
+  errorWrap: {
+    width: '90%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginBottom: 8,
+  },
+  errorText: {
+    color: RED,
+    fontSize: 13,
+    fontFamily: 'poppins-regular',
+    flex: 1,
+  },
+
+  // ── Stop button ────────────────────────────────────────────────────────
+  stopBtn: {
+    width: '90%',
+    backgroundColor: RED,
+    borderRadius: 25,
+    paddingVertical: 16,
+    alignItems: 'center',
+    marginBottom: 24,
+  },
+  stopBtnDisabled: {
+    backgroundColor: '#6b7280',
+  },
+  stopBtnText: {
+    fontSize: 16,
+    fontFamily: 'poppins-bold',
+    color: 'white',
+  },
+});

--- a/frontend/field-force-contractor/screens/DriveTimeTrackerScreen.tsx
+++ b/frontend/field-force-contractor/screens/DriveTimeTrackerScreen.tsx
@@ -87,7 +87,9 @@ function formatHMS(totalSeconds: number): string {
 }
 
 function formatTime12(iso: string): string {
-  const d = new Date(iso);
+  // Append Z if missing so JS parses as UTC → converts to local time correctly
+  const utc = iso.endsWith('Z') ? iso : iso + 'Z';
+  const d = new Date(utc);
   return d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
 }
 
@@ -153,10 +155,10 @@ export default function DriveTimeTrackerScreen() {
     };
   }, [session?.current_status, session?.is_active]);
 
-  // Change duty status
+  // Change duty status — also creates a session if none exists for today
   const changeStatus = async (newStatus: DutyStatus) => {
     if (changing) return;
-    if (session?.current_status === newStatus) return;
+    if (session?.is_active && session?.current_status === newStatus) return;
 
     setChanging(true);
     setError('');
@@ -238,7 +240,7 @@ export default function DriveTimeTrackerScreen() {
                 isSelected && { backgroundColor: cfg.color },
               ]}
               onPress={() => changeStatus(status)}
-              disabled={changing || !isActive}
+              disabled={changing}
               activeOpacity={0.7}
             >
               <Text style={[
@@ -318,10 +320,11 @@ export default function DriveTimeTrackerScreen() {
           </View>
         ) : (
           logs.map(log => {
+            const toUTC = (s: string) => new Date(s.endsWith('Z') ? s : s + 'Z');
             const durSecs = log.duration_seconds
               ?? (log.end_time
-                ? Math.floor((new Date(log.end_time).getTime() - new Date(log.start_time).getTime()) / 1000)
-                : Math.floor((Date.now() - new Date(log.start_time).getTime()) / 1000));
+                ? Math.floor((toUTC(log.end_time).getTime() - toUTC(log.start_time).getTime()) / 1000)
+                : Math.floor((Date.now() - toUTC(log.start_time).getTime()) / 1000));
 
             return (
               <View key={log.id} style={styles.logRow}>
@@ -351,21 +354,50 @@ export default function DriveTimeTrackerScreen() {
         </View>
       )}
 
-      {/* ── Stop Driving button ────────────────────────────────── */}
-      <TouchableOpacity
-        style={[styles.stopBtn, !isActive && styles.stopBtnDisabled]}
-        onPress={stopSession}
-        disabled={changing || !isActive}
-        activeOpacity={0.85}
-      >
-        {changing ? (
-          <ActivityIndicator color="white" />
-        ) : (
-          <Text style={styles.stopBtnText}>
-            {isActive ? 'Stop Driving' : 'Session Ended'}
-          </Text>
-        )}
-      </TouchableOpacity>
+      {/* ── Bottom CTA ────────────────────────────────────────── */}
+      {!session ? (
+        // No session yet — prompt to start by tapping a status button
+        <TouchableOpacity
+          style={[styles.stopBtn, { backgroundColor: GREEN }]}
+          onPress={() => changeStatus('on_duty')}
+          disabled={changing}
+          activeOpacity={0.85}
+        >
+          {changing ? (
+            <ActivityIndicator color="white" />
+          ) : (
+            <Text style={styles.stopBtnText}>Start Shift</Text>
+          )}
+        </TouchableOpacity>
+      ) : !isActive ? (
+        // Session ended — allow starting a new one
+        <TouchableOpacity
+          style={[styles.stopBtn, { backgroundColor: BLUE }]}
+          onPress={() => changeStatus('on_duty')}
+          disabled={changing}
+          activeOpacity={0.85}
+        >
+          {changing ? (
+            <ActivityIndicator color="white" />
+          ) : (
+            <Text style={styles.stopBtnText}>Start New Shift</Text>
+          )}
+        </TouchableOpacity>
+      ) : (
+        // Active session — stop it
+        <TouchableOpacity
+          style={styles.stopBtn}
+          onPress={stopSession}
+          disabled={changing}
+          activeOpacity={0.85}
+        >
+          {changing ? (
+            <ActivityIndicator color="white" />
+          ) : (
+            <Text style={styles.stopBtnText}>Stop Driving</Text>
+          )}
+        </TouchableOpacity>
+      )}
 
     </MainFrame>
   );

--- a/frontend/field-force-contractor/screens/HomeScreen.tsx
+++ b/frontend/field-force-contractor/screens/HomeScreen.tsx
@@ -5,6 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../App';
 import { MainFrame } from '../components/MainFrame';
+import { useAuth } from '../contexts/AuthContext';
 
 type Nav = NativeStackNavigationProp<RootStackParamList, 'Home'>;
 
@@ -30,6 +31,7 @@ const recentActivities = [
 
 export default function HomeScreen() {
     const navigation = useNavigation<Nav>();
+    const { logout } = useAuth();
     const [currentStatus, setCurrentStatus] = useState<Status>('work');
     const [isStatusOpen, setIsStatusOpen] = useState(false);
 
@@ -135,6 +137,15 @@ export default function HomeScreen() {
                 Edward / DOT research). Remove once that flow is in place. */}
             <TouchableOpacity
                 style={styles.devBtn}
+                onPress={() => navigation.navigate('Login')}
+                activeOpacity={0.85}
+            >
+                <Ionicons name="log-in-outline" size={16} color="#f59e0b" />
+                <Text style={styles.devBtnText}>Login Screen (Dev)</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+                style={styles.devBtn}
                 onPress={() => navigation.navigate('Inspection')}
                 activeOpacity={0.85}
             >
@@ -149,6 +160,17 @@ export default function HomeScreen() {
             >
                 <Ionicons name="speedometer-outline" size={16} color="#f59e0b" />
                 <Text style={styles.devBtnText}>Drive Time Tracker (Dev)</Text>
+            </TouchableOpacity>
+
+            {/* DEV — Log out and return to Login. Also run seed_dev.py on the
+                backend to reset demo data before showing the login flow. */}
+            <TouchableOpacity
+                style={[styles.devBtn, styles.devLogoutBtn]}
+                onPress={logout}
+                activeOpacity={0.85}
+            >
+                <Ionicons name="log-out-outline" size={16} color="#ef4444" />
+                <Text style={[styles.devBtnText, { color: '#ef4444' }]}>Logout (Dev)</Text>
             </TouchableOpacity>
 
         </MainFrame>
@@ -336,6 +358,10 @@ const styles = StyleSheet.create({
         color: '#f59e0b',
         fontSize: 13,
         fontFamily: 'poppins-bold',
+    },
+    devLogoutBtn: {
+        borderColor: '#ef4444',
+        backgroundColor: 'rgba(239,68,68,0.08)',
     },
 
 });

--- a/frontend/field-force-contractor/screens/HomeScreen.tsx
+++ b/frontend/field-force-contractor/screens/HomeScreen.tsx
@@ -142,6 +142,15 @@ export default function HomeScreen() {
                 <Text style={styles.devBtnText}>Open Truck Inspection (Dev)</Text>
             </TouchableOpacity>
 
+            <TouchableOpacity
+                style={styles.devBtn}
+                onPress={() => navigation.navigate('DriveTimeTracker')}
+                activeOpacity={0.85}
+            >
+                <Ionicons name="speedometer-outline" size={16} color="#f59e0b" />
+                <Text style={styles.devBtnText}>Drive Time Tracker (Dev)</Text>
+            </TouchableOpacity>
+
         </MainFrame>
     );
 }

--- a/frontend/field-force-contractor/screens/HomeScreen.tsx
+++ b/frontend/field-force-contractor/screens/HomeScreen.tsx
@@ -1,7 +1,12 @@
 import { useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../App';
 import { MainFrame } from '../components/MainFrame';
+
+type Nav = NativeStackNavigationProp<RootStackParamList, 'Home'>;
 
 type Status = 'driving' | 'work' | 'offline';
 
@@ -24,6 +29,7 @@ const recentActivities = [
 ];
 
 export default function HomeScreen() {
+    const navigation = useNavigation<Nav>();
     const [currentStatus, setCurrentStatus] = useState<Status>('work');
     const [isStatusOpen, setIsStatusOpen] = useState(false);
 
@@ -122,6 +128,19 @@ export default function HomeScreen() {
             <View style={styles.warning}>
                 <Text style={styles.warningText}>Over 11 hours drive time, time for a break</Text>
             </View>
+
+            {/* ── DEV-ONLY: Truck Inspection entry point ─────────────────────
+                Temporary trigger until the real business rule is wired up
+                (inspection should fire when a ticket is accepted — pending
+                Edward / DOT research). Remove once that flow is in place. */}
+            <TouchableOpacity
+                style={styles.devBtn}
+                onPress={() => navigation.navigate('Inspection')}
+                activeOpacity={0.85}
+            >
+                <Ionicons name="construct-outline" size={16} color="#f59e0b" />
+                <Text style={styles.devBtnText}>Open Truck Inspection (Dev)</Text>
+            </TouchableOpacity>
 
         </MainFrame>
     );
@@ -286,6 +305,28 @@ const styles = StyleSheet.create({
         fontSize: 13,
         fontFamily: 'poppins-bold',
         textAlign: 'center',
+    },
+
+    // Dev-only entry point to Truck Inspection — remove when the real
+    // trigger (ticket accepted) is wired up.
+    devBtn: {
+        width: '90%',
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 8,
+        paddingVertical: 12,
+        paddingHorizontal: 16,
+        borderRadius: 12,
+        borderWidth: 1,
+        borderColor: '#f59e0b',
+        backgroundColor: 'rgba(245,158,11,0.08)',
+        marginBottom: 24,
+    },
+    devBtnText: {
+        color: '#f59e0b',
+        fontSize: 13,
+        fontFamily: 'poppins-bold',
     },
 
 });

--- a/frontend/field-force-contractor/screens/InspectionScreen.tsx
+++ b/frontend/field-force-contractor/screens/InspectionScreen.tsx
@@ -80,8 +80,10 @@ export default function InspectionScreen() {
         );
         const when = latest.submitted_at ?? latest.created_at;
         if (when) {
+          // Backend returns ISO without 'Z' — append it so JS parses as UTC
+          const utcWhen = when.endsWith('Z') ? when : when + 'Z';
           const sameDay =
-            new Date(when).toLocaleDateString() === new Date().toLocaleDateString();
+            new Date(utcWhen).toLocaleDateString() === new Date().toLocaleDateString();
           if (sameDay) {
             navigation.replace('Dashboard');
             return;

--- a/frontend/field-force-contractor/screens/InspectionScreen.tsx
+++ b/frontend/field-force-contractor/screens/InspectionScreen.tsx
@@ -81,7 +81,7 @@ export default function InspectionScreen() {
         const when = latest.submitted_at ?? latest.created_at;
         if (when) {
           const sameDay =
-            new Date(when).toDateString() === new Date().toDateString();
+            new Date(when).toLocaleDateString() === new Date().toLocaleDateString();
           if (sameDay) {
             navigation.replace('Dashboard');
             return;

--- a/frontend/field-force-contractor/screens/InspectionScreen.tsx
+++ b/frontend/field-force-contractor/screens/InspectionScreen.tsx
@@ -83,7 +83,7 @@ export default function InspectionScreen() {
           const sameDay =
             new Date(when).toDateString() === new Date().toDateString();
           if (sameDay) {
-            navigation.replace('Home');
+            navigation.replace('Dashboard');
             return;
           }
         }
@@ -140,7 +140,7 @@ export default function InspectionScreen() {
         template_id: template.id,
         skipped: true,
       });
-      navigation.replace('Home');
+      navigation.replace('Dashboard');
     } catch (err) {
       const apiErr = err as ApiError;
       setSubmitError(apiErr.error || 'Failed to skip inspection.');
@@ -160,7 +160,7 @@ export default function InspectionScreen() {
         template_id: template.id,
         no_issues_found: true,
       });
-      navigation.replace('Home');
+      navigation.replace('Dashboard');
     } catch (err) {
       const apiErr = err as ApiError;
       setSubmitError(apiErr.error || 'Failed to submit inspection.');
@@ -188,7 +188,7 @@ export default function InspectionScreen() {
         no_issues_found: false,
         results,
       });
-      navigation.replace('Home');
+      navigation.replace('Dashboard');
     } catch (err) {
       const apiErr = err as ApiError;
       setSubmitError(apiErr.error || 'Failed to submit inspection.');

--- a/frontend/field-force-contractor/screens/LoginScreen.tsx
+++ b/frontend/field-force-contractor/screens/LoginScreen.tsx
@@ -305,23 +305,29 @@ export default function LoginScreen() {
               </View>
             )}
 
-            {/* Email / Username input — label and behavior controlled by LOGIN_FIELD at the top */}
+            {/* Email / Username input — behavior controlled by LOGIN_FIELD at the top */}
             <View style={styles.fieldGroup}>
-              <Text style={styles.label}>{fieldConfig.label}</Text>
-              <TextInput
-                style={[
-                  styles.input,
-                  identifierError !== '' ? styles.inputError : null, // red border if error
-                ]}
-                value={identifier}
-                onChangeText={handleIdentifierChange}
-                onBlur={validateIdentifier} // validate when they leave the field
-                placeholder={fieldConfig.placeholder}
-                placeholderTextColor={colors.textMuted}
-                keyboardType={fieldConfig.keyboardType}
-                autoCapitalize={fieldConfig.autoCapitalize}
-                autoCorrect={false}
-              />
+              <View>
+                <TextInput
+                  style={[
+                    styles.input,
+                    identifier !== '' && styles.inputFilled,
+                    identifierError !== '' ? styles.inputError : null, // red border if error
+                  ]}
+                  value={identifier}
+                  onChangeText={handleIdentifierChange}
+                  onBlur={validateIdentifier} // validate when they leave the field
+                  placeholder=""
+                  keyboardType={fieldConfig.keyboardType}
+                  autoCapitalize={fieldConfig.autoCapitalize}
+                  autoCorrect={false}
+                />
+                {identifier === '' && (
+                  <Text style={styles.neonPlaceholder} pointerEvents="none">
+                    {fieldConfig.placeholder}
+                  </Text>
+                )}
+              </View>
               {/* Only shows the error text if there is one */}
               {identifierError !== '' && (
                 <View style={styles.fieldErrorRow}>
@@ -333,24 +339,28 @@ export default function LoginScreen() {
 
             {/* Password input */}
             <View style={styles.fieldGroup}>
-              <Text style={styles.label}>Password</Text>
               {/* We wrap the input in a View so we can position the eye icon on top of it */}
               <View>
                 <TextInput
                   style={[
                     styles.input,
                     styles.inputPadRight, // extra right padding so text doesn't overlap the eye icon
+                    password !== '' && styles.inputFilled,
                     passwordError !== '' ? styles.inputError : null,
                   ]}
                   value={password}
                   onChangeText={handlePasswordChange}
                   onBlur={validatePassword}
-                  placeholder="Min. 6 characters"
-                  placeholderTextColor={colors.textMuted}
+                  placeholder=""
                   secureTextEntry={!showPassword} // hides/shows the password text
                   autoCapitalize="none"
                   autoCorrect={false}
                 />
+                {password === '' && (
+                  <Text style={styles.neonPlaceholder} pointerEvents="none">
+                    Password
+                  </Text>
+                )}
                 {/* Eye icon button — toggles between showing and hiding the password */}
                 <TouchableOpacity
                   style={styles.eyeBtn}
@@ -477,6 +487,18 @@ const styles = StyleSheet.create({
     fontFamily:        fonts.regular,
     color:             colors.textWhite,
     fontSize:          fontSize.base,
+  },
+  inputFilled:   { backgroundColor: 'rgba(10,14,26,0.8)' }, // darkens when user starts typing
+  neonPlaceholder: {
+    position:          'absolute',
+    left:              16,
+    top:               14,
+    fontFamily:        fonts.regular,
+    fontSize:          fontSize.base,
+    color:             '#ff8c00',
+    textShadowColor:   'rgba(255,140,0,0.9)',
+    textShadowOffset:  { width: 0, height: 0 },
+    textShadowRadius:  10,
   },
   inputError:    { borderColor: colors.error }, // overrides the default border with red
   inputPadRight: { paddingRight: 48 },           // keeps text from going under the eye button

--- a/frontend/field-force-contractor/screens/LoginScreen.tsx
+++ b/frontend/field-force-contractor/screens/LoginScreen.tsx
@@ -35,12 +35,16 @@ import { useAuth }            from '../contexts/AuthContext';
 type Nav = NativeStackNavigationProp<RootStackParamList, 'Login'>;
 
 // ─────────────────────────────────────────────────────────────────────────────
-// ⚙️  STAKEHOLDER CONFIG — change this one line after Tuesday's meeting
+// ⚙️  STAKEHOLDER CONFIG — change this one line if the policy shifts
 //
-//   'email'    = contractor logs in with their email address
-//   'username' = contractor logs in with a username
+//   'email'    = contractor logs in with their email address only
+//   'username' = contractor logs in with a username only
+//   'either'   = single field accepts email OR username (current default)
+//
+// The backend /auth/login endpoint detects '@' and looks up the correct
+// column, so all three options send the same `identifier` key over the wire.
 // ─────────────────────────────────────────────────────────────────────────────
-const LOGIN_FIELD: 'email' | 'username' = 'username';
+const LOGIN_FIELD: 'email' | 'username' | 'either' = 'either';
 
 // Labels, placeholder text, and keyboard type are all derived from the flag above
 // so only the one line above ever needs to change — nothing else in this file
@@ -54,6 +58,14 @@ const FIELD_CONFIG = {
   username: {
     label:          'Username',
     placeholder:    'Enter your username',
+    keyboardType:   'default' as const,
+    autoCapitalize: 'none' as const,
+  },
+  // 'either' — single field mode. Default keyboard since we can't assume
+  // they'll type an email; email-address keyboard would hide the period key.
+  either: {
+    label:          'Username or Email',
+    placeholder:    'Username or email',
     keyboardType:   'default' as const,
     autoCapitalize: 'none' as const,
   },
@@ -191,8 +203,10 @@ export default function LoginScreen() {
       }
 
       // ── PRODUCTION: call the real backend /auth/login endpoint ────────
+      // Always send `identifier` — the backend detects whether it's an email
+      // or username based on the '@' character and picks the right column.
       const res = await api.post<LoginResponse>('/auth/login', {
-        [LOGIN_FIELD]: identifier.trim(),
+        identifier: identifier.trim(),
         password,
       });
 

--- a/frontend/field-force-contractor/screens/LoginScreen.tsx
+++ b/frontend/field-force-contractor/screens/LoginScreen.tsx
@@ -64,8 +64,8 @@ const FIELD_CONFIG = {
   // 'either' — single field mode. Default keyboard since we can't assume
   // they'll type an email; email-address keyboard would hide the period key.
   either: {
-    label:          'Username or Email',
-    placeholder:    'Username or email',
+    label:          'Username',
+    placeholder:    'Username',
     keyboardType:   'default' as const,
     autoCapitalize: 'none' as const,
   },


### PR DESCRIPTION
## What this PR adds

- Full FMCSA Hours of Service (HOS) duty status tracking
- Duty statuses: Driving, On-Duty, Off-Duty, Sleeper Berth
- 11-hour drive limit enforcement
- 14-hour on-duty window tracking
- Required 10-hour off-duty reset
- GPS session logging with start/end times
- Interactive Drive Time Tracker screen
- Auth guard added to navigator
- Dev logout button on HomeScreen

## Why this matters

FMCSA HOS compliance is a legal requirement for field contractors operating in oil & gas. Without drive time tracking the app cannot be used in a real field environment — this is one of the core requirements from the stakeholder meetings.

## Tested
- Endpoints tested locally
- Screen tested in Expo
- Deploy-ready