### PR TITLE
Feature/Login - Auth flow, MainFrame integration, profile screens, and UI updates

### DIFF
--- a/frontend/field-force-contractor/App.tsx
+++ b/frontend/field-force-contractor/App.tsx
@@ -11,6 +11,7 @@ import { LoadFonts } from "./utils/LoadFonts";
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
+import { ThemeProvider } from './contexts/ThemeContext';
 
 // ── Jonathan ──────────────────────────────────────
 import {Blank} from "./screens/Blank";
@@ -34,8 +35,9 @@ import PasswordResetScreen   from "./screens/PasswordResetScreen";
 import OfflinePinResetScreen from "./screens/OfflinePinResetScreen";
 
 // ── TROY — Profile screens ───────────────────────────────────
-import ProfileScreen from "./screens/ProfileScreen";
-import LicenseScreen from "./screens/LicenseScreen";
+import ProfileScreen     from "./screens/ProfileScreen";
+import LicenseScreen     from "./screens/LicenseScreen";
+import TaskHistoryScreen from "./screens/TaskHistoryScreen";
 
 export type RootStackParamList = {
   // ── Always visible ───────────────────────────────────────────
@@ -58,13 +60,22 @@ export type RootStackParamList = {
   // ── Troy — Auth screens ──────────────────────────────────────
   Login:           undefined;
   OfflineLogin:    undefined;
-  BiometricCheck:  undefined;
+
+  // BiometricCheck receives the pending token and user from LoginScreen.
+  // login() is NOT called until the biometric scan succeeds here, ensuring
+  // isAuthenticated never becomes true before identity is verified.
+  BiometricCheck: {
+    pendingToken: string;
+    pendingUser:  { id: number; username: string; role: string };
+  };
+
   PasswordReset:   undefined;
   OfflinePinReset: undefined;
 
   // ── Troy — Profile screens ───────────────────────────────────
   Profile:         undefined;
   LicenseDetails:  undefined;
+  TaskHistory:     undefined;
 
   // ── Aldo — Inspection screen + AI assist + Drive Time ────────
   Inspection:        { bypassGate?: boolean } | undefined;
@@ -113,6 +124,7 @@ function RootNavigator() {
           <StackNavigator.Screen name="TicketDetail"     component={TicketDetailScreen}     />
           <StackNavigator.Screen name="Profile"          component={ProfileScreen}          />
           <StackNavigator.Screen name="LicenseDetails"   component={LicenseScreen}          />
+          <StackNavigator.Screen name="TaskHistory"      component={TaskHistoryScreen}      />
           <StackNavigator.Screen name="InspectionAssist" component={InspectionAssistScreen} />
           <StackNavigator.Screen name="DriveTimeTracker" component={DriveTimeTrackerScreen} />
           <StackNavigator.Screen name="SavedReports"     component={SavedReportsScreen}     />
@@ -150,10 +162,12 @@ export default function App() {
   if (!externalFontsLoaded) return null;
 
   return (
-    <AuthProvider>
-      <NavigationContainer>
-        <RootNavigator />
-      </NavigationContainer>
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <NavigationContainer>
+          <RootNavigator />
+        </NavigationContainer>
+      </AuthProvider>
+    </ThemeProvider>
   );
 }

--- a/frontend/field-force-contractor/components/MainFrame.tsx
+++ b/frontend/field-force-contractor/components/MainFrame.tsx
@@ -1,64 +1,157 @@
-import {Styles} from "@/constants/Styles"
-import {Assets} from "@/constants/Assets"
-import {FC,ReactNode} from "react"
-import {View,ImageBackground,ScrollView} from "react-native"
-import {Header,HeaderVariant} from "@/components/Header"
-import { Menu,MenuOptions}  from "@/components/Menu"
-import {Menus} from "@/constants/Menus"
-import { useRoute } from "@react-navigation/native"
+// MainFrame.tsx  —  Jonathan
+//
+// The single layout wrapper every screen in the app uses.
+// Provides background image, status-bar spacer, logo header,
+// optional header menu, scrollable body, and footer nav.
+//
+// Uses useRoute() to auto-detect the current page name and defaults
+// to Menu2 which shows just the page title — no redundant nav links.
+//
+// ── SubHeader ─────────────────────────────────────────────────────────────────
+// Also exports SubHeader — the navy back-arrow + centred title bar used on
+// inner / detail screens. Previously lived in FieldForceHeader.tsx but is
+// exported here so everything routes through a single component file and
+// FieldForceHeader.tsx can be removed entirely.
+//
+// Usage:
+//   import { MainFrame, SubHeader } from '../components/MainFrame';
+//
+//   <MainFrame header="home" ...>
+//     <View style={{ alignSelf: 'stretch' }}>
+//       <SubHeader title="Screen Title" />
+//     </View>
+//     ... page content ...
+//   </MainFrame>
+//
+// The alignSelf:'stretch' wrapper is needed so SubHeader spans edge-to-edge
+// inside MainFrame's centered ScrollView.
+// ──────────────────────────────────────────────────────────────────────────────
 
-type Props = {
-children?:ReactNode
-header?: HeaderVariant
-headerMenu?: MenuOptions
-footerMenu?: MenuOptions
-strip?: "menus" | "all" | "header"
-injectHeader?:ReactNode
-injectFooter?:ReactNode
+import { FC, ReactNode }  from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  ImageBackground,
+  ScrollView,
+  StyleSheet,
+} from 'react-native';
+import { Ionicons }       from '@expo/vector-icons';
+import { useNavigation, useRoute } from '@react-navigation/native';
+
+import { Styles }              from '@/constants/Styles';
+import { Assets }              from '@/constants/Assets';
+import { colors, spacing, fontSize, fonts } from '@/constants/theme';
+import { Header, HeaderVariant } from '@/components/Header';
+import { Menu, MenuOptions }   from '@/components/Menu';
+import { Menus }               from '@/constants/Menus';
+
+// ── SubHeader ─────────────────────────────────────────────────────────────────
+
+type SubHeaderProps = {
+  title:   string;
+  onBack?: () => void;
+};
+
+export function SubHeader({ title, onBack }: SubHeaderProps) {
+  const navigation = useNavigation<any>();
+
+  return (
+    <View style={subStyles.subHeader}>
+      <TouchableOpacity
+        style={subStyles.backBtn}
+        onPress={onBack ?? (() => navigation.goBack())}
+        activeOpacity={0.7}
+      >
+        <Ionicons name="chevron-back" size={24} color={colors.textWhite} />
+      </TouchableOpacity>
+
+      <Text style={subStyles.subTitle}>{title}</Text>
+
+      {/* Spacer keeps title centred */}
+      <View style={subStyles.backBtn} />
+    </View>
+  );
 }
 
-export const MainFrame:FC<Props> = (props) =>{
- const route = useRoute();
- const pageName = route.name;
- const renderHeaderMenu: MenuOptions =
-  props.strip === "menus" || props.strip === "all"
-    ? ["none",[]]
-    : props.headerMenu ?? ["Menu2", [pageName]];
+const subStyles = StyleSheet.create({
+  subHeader: {
+    flexDirection:     'row',
+    alignItems:        'center',
+    justifyContent:    'space-between',
+    backgroundColor:   '#142040',
+    paddingHorizontal: spacing.md,
+    paddingVertical:   12,
+  },
+  backBtn: {
+    width:      36,
+    alignItems: 'center',
+  },
+  subTitle: {
+    flex:          1,
+    fontFamily:    fonts.bold,
+    color:         colors.textWhite,
+    fontSize:      fontSize.lg,
+    textAlign:     'center',
+    letterSpacing: 0.3,
+  },
+});
 
- const renderFooterMenu: MenuOptions =
-  props.strip === "menus" || props.strip === "all"
-    ? ["none",[]]
-    : props.footerMenu ?? ["Menu3", Menus.Footer];
+// ── MainFrame ─────────────────────────────────────────────────────────────────
 
-  const renderHeader = (props.strip != "all" && props.strip != "header") ? props.header : "none"
+type Props = {
+  children?:     ReactNode;
+  header?:       HeaderVariant;
+  headerMenu?:   MenuOptions;
+  footerMenu?:   MenuOptions;
+  strip?:        'menus' | 'all' | 'header';
+  injectHeader?: ReactNode;
+  injectFooter?: ReactNode;
+};
 
-  return(<>
-    <ImageBackground source={Assets.backgrounds.MainFrame.MainbackgroundImage} style={Styles.MainFrame.BackgroundImageSize}>
+export const MainFrame: FC<Props> = (props) => {
+  const route    = useRoute();
+  const pageName = route.name;
+
+  const renderHeaderMenu: MenuOptions =
+    props.strip === 'menus' || props.strip === 'all'
+      ? ['none', []]
+      : props.headerMenu ?? ['Menu2', [pageName]];
+
+  const renderFooterMenu: MenuOptions =
+    props.strip === 'menus' || props.strip === 'all'
+      ? ['none', []]
+      : props.footerMenu ?? ['Menu3', Menus.Footer];
+
+  const renderHeader = (props.strip !== 'all' && props.strip !== 'header')
+    ? props.header
+    : 'none';
+
+  return (
+    <ImageBackground
+      source={Assets.backgrounds.MainFrame.MainbackgroundImage}
+      style={Styles.MainFrame.BackgroundImageSize}
+    >
       <View style={Styles.MainFrame.Window}>
-       <View style={Styles.MainFrame.Header}>
-        <View style={Styles.MainFrame.SpaceHeader}/>
-        <Header  header={renderHeader}/>
-        <Menu menuOptions={renderHeaderMenu} />
-        {
-          props.injectHeader
-        }
+
+        <View style={Styles.MainFrame.Header}>
+          <View style={Styles.MainFrame.SpaceHeader} />
+          <Header header={renderHeader} />
+          <Menu menuOptions={renderHeaderMenu} />
+          {props.injectHeader}
         </View>
 
         <ScrollView contentContainerStyle={Styles.MainFrame.Body}>
-          {
-          props.children
-          }
+          {props.children}
         </ScrollView>
 
         <View style={Styles.MainFrame.Footer}>
-           {
-            props.injectFooter
-           }
-          <Menu menuOptions={renderFooterMenu}/>
-          <View style={Styles.MainFrame.SpaceHeader}/>
+          {props.injectFooter}
+          <Menu menuOptions={renderFooterMenu} />
+          <View style={Styles.MainFrame.SpaceHeader} />
         </View>
 
       </View>
     </ImageBackground>
- </>)
-}
+  );
+};

--- a/frontend/field-force-contractor/constants/theme.ts
+++ b/frontend/field-force-contractor/constants/theme.ts
@@ -1,52 +1,85 @@
-/**
- * constants/theme.ts — Design tokens for Troy's screens
- *
- * Single source of truth for colors, spacing, typography, and
- * border-radius across all Field Force auth and profile screens.
- *
- * Usage:
- *   import { colors, spacing, fontSize, fonts } from '../constants/theme';
- *
- * Font keys must match the keys registered in utils/LoadFonts.tsx.
- */
+// ============================================
+// theme.ts — Shared design tokens
+// Import this anywhere you need colors,
+// spacing, typography, or border radius.
+//
+// COLORS: Do NOT import `colors` directly in
+// screens anymore. Use the useTheme() hook
+// from ThemeContext instead so light/dark mode
+// works automatically across the whole app.
+//
+// spacing, radius, fontSize, letterSpacing,
+// and fonts are static — import those directly.
+// ============================================
 
-// ── Colors ───────────────────────────────────────────────────
-export const colors = {
-  // Backgrounds — dark navy palette from the approved screenshots
-  background:  '#0a0e1a',
-  card:        '#1c2330',
-  cardAlt:     '#2d3544',
-  cardHover:   '#3d4554',
+// ── Dark palette (default) ────────────────────────────────────
+export const darkColors = {
+  background:   '#0a0e1a',
+  card:         '#1c2330',
+  cardAlt:      '#2d3544',
+  cardHover:    '#3d4554',
 
-  // Brand — orange primary accent
   primary:      '#ff8c00',
   primaryDark:  '#ff6b00',
   primaryLight: '#ffa000',
-  primaryFaint: 'rgba(255,140,0,0.10)',
+  primaryFaint: 'rgba(255, 140, 0, 0.1)',
 
-  // Text
   textWhite:    '#ffffff',
   textLight:    '#d1d5db',
   textMuted:    '#6b7280',
   textDisabled: '#4b5563',
 
-  // Borders
   border:       '#2d3544',
   borderActive: '#ff8c00',
   borderHover:  '#3d4554',
 
-  // Status
-  success:     '#34d399',
-  successDot:  '#10b981',
-  warning:     '#f59e0b',
-  error:       '#f87171',
-  errorTitle:  '#fca5a5',
-  errorBg:     'rgba(127,29,29,0.30)',
-  errorBorder: 'rgba(153,27,27,0.60)',
-  errorIcon:   'rgba(127,29,29,0.40)',
+  success:      '#34d399',
+  successDot:   '#10b981',
+  warning:      '#f59e0b',
+  error:        '#f87171',
+  errorTitle:   '#fca5a5',
+  errorBg:      'rgba(127, 29, 29, 0.3)',
+  errorBorder:  'rgba(153, 27, 27, 0.6)',
+  errorIcon:    'rgba(127, 29, 29, 0.4)',
 };
 
-// ── Spacing ──────────────────────────────────────────────────
+// ── Light palette ─────────────────────────────────────────────
+export const lightColors = {
+  background:   '#f0f4f8',          // soft off-white — easier on the eyes than pure white
+  card:         '#ffffff',          // white cards
+  cardAlt:      '#e2e8f0',          // light gray for borders/dividers
+  cardHover:    '#cbd5e1',          // slightly darker hover
+
+  primary:      '#d97706',          // amber — slightly darker so it reads on light bg
+  primaryDark:  '#b45309',
+  primaryLight: '#f59e0b',
+  primaryFaint: 'rgba(217, 119, 6, 0.08)',
+
+  textWhite:    '#0f172a',          // near-black — main text on light bg
+  textLight:    '#334155',          // dark slate — labels, secondary text
+  textMuted:    '#64748b',          // medium gray — placeholders
+  textDisabled: '#94a3b8',          // lighter gray — disabled
+
+  border:       '#cbd5e1',          // light blue-gray border
+  borderActive: '#d97706',          // amber active border
+  borderHover:  '#94a3b8',
+
+  success:      '#059669',          // darker green — readable on light bg
+  successDot:   '#047857',
+  warning:      '#d97706',
+  error:        '#dc2626',          // darker red — readable on light bg
+  errorTitle:   '#b91c1c',
+  errorBg:      'rgba(220, 38, 38, 0.08)',
+  errorBorder:  'rgba(185, 28, 28, 0.3)',
+  errorIcon:    'rgba(220, 38, 38, 0.1)',
+};
+
+// ── Static fallback (for files not yet on ThemeContext) ───────
+// This matches the original dark palette so existing imports
+// don't break while the migration is in progress.
+export const colors = darkColors;
+
+// ── Static tokens (same for both modes) ──────────────────────
 export const spacing = {
   xs:  4,
   sm:  8,
@@ -56,14 +89,12 @@ export const spacing = {
   xxl: 48,
 };
 
-// ── Border radius ────────────────────────────────────────────
 export const radius = {
   sm: 6,
   md: 10,
   lg: 16,
 };
 
-// ── Font sizes ───────────────────────────────────────────────
 export const fontSize = {
   tiny: 10,
   xs:   11,
@@ -74,7 +105,12 @@ export const fontSize = {
   xl:   22,
 };
 
-// ── Letter spacing ───────────────────────────────────────────
+export const fonts = {
+  regular:    'poppins-regular',
+  bold:       'poppins-bold',
+  boldItalic: 'poppins-bold-italic',
+};
+
 export const letterSpacing = {
   tight:  0.5,
   normal: 1,
@@ -82,10 +118,5 @@ export const letterSpacing = {
   wider:  3,
 };
 
-// ── Font families — must match keys in utils/LoadFonts.tsx ───
-export const fonts = {
-  regular:    'poppins-regular',
-  bold:       'poppins-bold',
-  italic:     'poppins-italic',
-  boldItalic: 'poppins-bolditalic',
-};
+// Type alias so screens can type-hint the colors object
+export type AppColors = typeof darkColors;

--- a/frontend/field-force-contractor/contexts/ThemeContext.tsx
+++ b/frontend/field-force-contractor/contexts/ThemeContext.tsx
@@ -1,0 +1,83 @@
+// ThemeContext.tsx
+// Provides the active color palette and a toggle to the whole app.
+//
+// Usage in any screen:
+//   import { useTheme } from '../contexts/ThemeContext';
+//   const { colors } = useTheme();
+//
+// The `colors` object returned is either the dark or light palette
+// from theme.ts — identical shape, so no other code changes are needed
+// in a screen beyond swapping the import.
+//
+// The user's preference is persisted to AsyncStorage under
+// 'settings:lightMode' — the same key ProfileScreen writes to —
+// so changes in Settings take effect immediately on the next render.
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  ReactNode,
+} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { darkColors, lightColors, AppColors } from '../constants/theme';
+
+// ── Key must match ProfileScreen's SETTINGS_LIGHT_MODE_KEY ────
+const LIGHT_MODE_KEY = 'settings:lightMode';
+
+// ── Context type ──────────────────────────────────────────────
+interface ThemeContextType {
+  colors:    AppColors;
+  lightMode: boolean;
+  setLightMode: (value: boolean) => Promise<void>;
+}
+
+const ThemeContext = createContext<ThemeContextType | null>(null);
+
+// ── Provider ─────────────────────────────────────────────────
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [lightMode, setLightModeState] = useState(false);
+
+  // Load saved preference on mount
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const saved = await AsyncStorage.getItem(LIGHT_MODE_KEY);
+        if (saved === 'true') setLightModeState(true);
+      } catch {
+        // Fall back to dark mode if AsyncStorage is unavailable
+      }
+    };
+    load();
+  }, []);
+
+  // Saves to AsyncStorage and updates state immediately
+  const setLightMode = async (value: boolean) => {
+    try {
+      await AsyncStorage.setItem(LIGHT_MODE_KEY, String(value));
+    } catch {
+      // Persist failure is non-fatal — state still updates in memory
+    }
+    setLightModeState(value);
+  };
+
+  return (
+    <ThemeContext.Provider
+      value={{
+        colors:    lightMode ? lightColors : darkColors,
+        lightMode,
+        setLightMode,
+      }}
+    >
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+// ── Hook ─────────────────────────────────────────────────────
+export function useTheme(): ThemeContextType {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme() must be used inside <ThemeProvider>');
+  return ctx;
+}

--- a/frontend/field-force-contractor/screens/BiometricScreen.tsx
+++ b/frontend/field-force-contractor/screens/BiometricScreen.tsx
@@ -1,33 +1,27 @@
 // BiometricScreen.tsx  —  Troy
+//
 // Online biometric verification screen.
-// Reached after a successful credential login (online OR offline pill state).
+// Reached after a successful credential login on LoginScreen.
 //
 // Flow:
-//   Login → BiometricCheck (this screen) → Dashboard       (scan succeeds)
-//                                        → OfflineLogin    (scan fails → PIN entry)
+//   LoginScreen (credentials OK) → BiometricCheck (this screen) → Home (scan succeeds)
+//                                                               → OfflineLogin (scan fails)
 //
-// OfflineLoginScreen is now purely a PIN entry screen.
-// The biometric step for ALL cases lives here.
+// ── WHY login() IS CALLED HERE, NOT IN LoginScreen ────────────────────────────
+// If App.tsx switches navigation stacks the moment isAuthenticated becomes true,
+// calling login() in LoginScreen before navigating here would cause this screen
+// to be unmounted immediately — the user would skip biometrics entirely.
 //
-// ─── DEV MODE NOTE ────────────────────────────────────────────────────────────
-//
-//  DEV_MODE = true  → scan ALWAYS SUCCEEDS so the full success flow can be tested.
-//                     Tap "Force Fail (Dev)" to manually trigger failure and
-//                     reach the PIN screen.
-//
-//  DEV_MODE = false → uses real expo-local-authentication (production).
-//                     Replace the setTimeout block in handleScan() with:
-//
-//    import * as LocalAuthentication from 'expo-local-authentication';
-//    const result = await LocalAuthentication.authenticateAsync({
-//      promptMessage: 'Verify your identity',
-//    });
-//    if (result.success) { navigation.replace('Inspection'); }
-//    else { setScanState('failed'); }
-//
+// Instead LoginScreen passes the API token and user as navigation params.
+// This screen calls login() only after a successful biometric scan, ensuring
+// the user is never considered authenticated until their identity is verified.
 // ──────────────────────────────────────────────────────────────────────────────
+//
+// DEV MODE = true  → scan always succeeds. Tap "Force Fail (Dev)" to test
+//                    the failure path.
+// DEV MODE = false → uses real expo-local-authentication.
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -36,80 +30,80 @@ import {
   StatusBar,
   ActivityIndicator,
 } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
-import { useNavigation } from '@react-navigation/native';
-import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { RootStackParamList } from '../App';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Ionicons }  from '@expo/vector-icons';
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import { NativeStackNavigationProp }          from '@react-navigation/native-stack';
+
+import { RootStackParamList }     from '../App';
 import { MainFrame } from '../components/MainFrame';
+import { SETTINGS_BIOMETRIC_KEY } from './ProfileScreen';
+import { useAuth }                from '../contexts/AuthContext';
 import { colors, spacing, radius, fontSize, fonts } from '../constants/theme';
 
-type Nav = NativeStackNavigationProp<RootStackParamList, 'BiometricCheck'>;
+type Nav   = NativeStackNavigationProp<RootStackParamList, 'BiometricCheck'>;
+type Route = RouteProp<RootStackParamList, 'BiometricCheck'>;
 
-// ─────────────────────────────────────────────────────────────────────────────
-// ⚙️  DEV MODE — set to false when real biometrics are ready.
-//
-//  true  = scan always succeeds. Use "Force Fail (Dev)" to test failure path.
-//  false = uses real expo-local-authentication hardware call.
-// ─────────────────────────────────────────────────────────────────────────────
 const DEV_MODE = true;
-
-// Amber — consistent with Login button and "Restricted Access" throughout the app
-const AMBER = '#f59e0b';
+const AMBER    = '#f59e0b';
 
 export default function BiometricScreen() {
-  const navigation = useNavigation<Nav>();
+  const navigation           = useNavigation<Nav>();
+  const route                = useRoute<Route>();
+  const { login }            = useAuth();
 
-  // Online/Offline toggle — mirrors the pill on the Login screen.
-  // Biometrics are local to the device and work regardless of connection.
-  // This pill is a server-status indicator and testing aid only.
-  const [isOffline, setIsOffline] = useState(false);
+  // Pending credentials passed from LoginScreen — not yet committed to AuthContext
+  const { pendingToken, pendingUser } = route.params;
 
-  // 'idle'     = waiting for the user to tap
-  // 'scanning' = scan in progress (spinner shown)
-  // 'failed'   = scan failed — retry + PIN fallback appear
-  const [scanState, setScanState] = useState('idle');
-
-  // Which biometric method is selected — face or fingerprint
+  const [isOffline,      setIsOffline]      = useState(false);
+  const [scanState,      setScanState]      = useState('idle');
   const [selectedMethod, setSelectedMethod] = useState('fingerprint');
 
-  // When the user switches methods, reset any scan state too
+  // Load the user's saved biometric preference from AsyncStorage so the
+  // correct method is pre-selected when this screen opens
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const saved = await AsyncStorage.getItem(SETTINGS_BIOMETRIC_KEY);
+        if (saved === 'face' || saved === 'fingerprint') {
+          setSelectedMethod(saved);
+        }
+      } catch {
+        // Fall back to fingerprint default
+      }
+    };
+    load();
+  }, []);
+
   const switchMethod = (method: string) => {
     setSelectedMethod(method);
     setScanState('idle');
   };
 
-  // This runs when the user taps the large scan button
-  const handleScan = () => {
+  const handleScan = async () => {
     if (scanState === 'scanning') return;
     setScanState('scanning');
 
-    setTimeout(() => {
+    setTimeout(async () => {
       if (DEV_MODE) {
-        // DEV MODE: always succeed so the full flow can be tested.
-        // Use "Force Fail (Dev)" button to test the failure/PIN path.
-        navigation.replace('Inspection');
+        await login(pendingToken, pendingUser);
+        navigation.replace('Home');
         return;
       }
-
-      // PRODUCTION: replace with real LocalAuthentication — see dev note above
       const scanWorked = Math.random() > 0.3;
       if (scanWorked) {
-        navigation.replace('Inspection');
+        await login(pendingToken, pendingUser);
+        navigation.replace('Home');
       } else {
         setScanState('failed');
       }
     }, 1500);
   };
 
-  // DEV ONLY — forces a failure so the PIN fallback path can be tested
   const handleForceFail = () => setScanState('failed');
+  const handleUsePIN    = () => navigation.replace('OfflineLogin');
 
-  // "Use PIN instead" — navigates to OfflineLoginScreen which is now
-  // purely a PIN entry screen. Works the same whether online or offline.
-  const handleUsePIN = () => navigation.replace('OfflineLogin');
-
-  const getScanIcon = () => (selectedMethod === 'face' ? 'scan' : 'finger-print');
-
+  const getScanIcon      = () => selectedMethod === 'face' ? 'scan' : 'finger-print';
   const getScanIconColor = () => {
     if (scanState === 'failed')   return colors.error;
     if (scanState === 'scanning') return colors.textWhite;
@@ -117,19 +111,13 @@ export default function BiometricScreen() {
   };
 
   return (
-    <MainFrame header="default" headerMenu={['none']} footerMenu={['none']}>
-        <StatusBar barStyle="light-content" backgroundColor="transparent" translucent />
+    <MainFrame header="default" headerMenu={['Menu2', ['Security Check']]} footerMenu={['none', []]}>
+      <StatusBar barStyle="light-content" backgroundColor="transparent" translucent />
 
-        {/* ── Online / Offline status pill ──────────────────────────────────
-            Sits directly below "Security Check" for visibility.
-            Tapping it toggles the mode. Biometrics work locally on the
-            device regardless — this pill is a server-status indicator only. */}
+      <View style={styles.topWrap}>
         <TouchableOpacity
           style={styles.statusPill}
-          onPress={() => {
-            setIsOffline(!isOffline);
-            setScanState('idle');
-          }}
+          onPress={() => { setIsOffline(!isOffline); setScanState('idle'); }}
           activeOpacity={0.8}
         >
           <Ionicons
@@ -141,148 +129,103 @@ export default function BiometricScreen() {
             {isOffline ? 'Offline' : 'Online'}
           </Text>
         </TouchableOpacity>
+      </View>
 
-        <View style={styles.body}>
+      <View style={styles.body}>
 
-          {/* Prompt text — white for clear readability on the dark background */}
-          <Text style={styles.promptText}>BIOMETRIC IDENTITY</Text>
-          <Text style={styles.promptText}>CHECK REQUIRED</Text>
+        <Text style={styles.promptText}>BIOMETRIC IDENTITY</Text>
+        <Text style={styles.promptText}>CHECK REQUIRED</Text>
 
-          {/* ── Method toggle — Face ID / Fingerprint ──────────────────────
-              Active method highlights in amber to match the Login button.  */}
-          <View style={styles.methodRow}>
-
-            <TouchableOpacity
-              style={[styles.methodBtn, selectedMethod === 'face' && styles.methodBtnActive]}
-              onPress={() => switchMethod('face')}
-              activeOpacity={0.8}
-            >
-              <Ionicons
-                name="scan-outline"
-                size={20}
-                color={selectedMethod === 'face' ? AMBER : colors.textMuted}
-              />
-              <Text style={[styles.methodLabel, selectedMethod === 'face' && styles.methodLabelActive]}>
-                Face ID
-              </Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={[styles.methodBtn, selectedMethod === 'fingerprint' && styles.methodBtnActive]}
-              onPress={() => switchMethod('fingerprint')}
-              activeOpacity={0.8}
-            >
-              <Ionicons
-                name="finger-print"
-                size={20}
-                color={selectedMethod === 'fingerprint' ? AMBER : colors.textMuted}
-              />
-              <Text style={[styles.methodLabel, selectedMethod === 'fingerprint' && styles.methodLabelActive]}>
-                Fingerprint
-              </Text>
-            </TouchableOpacity>
-
-          </View>
-
-          {/* ── Large scan button ────────────────────────────────────────────
-              Border and icon color reflect current scan state:
-                idle     = amber  (inviting tap)
-                scanning = muted gray + spinner
-                failed   = error red                                         */}
+        {/* Method toggle — pre-selected from saved preference */}
+        <View style={styles.methodRow}>
           <TouchableOpacity
-            style={[
-              styles.scanButton,
-              scanState === 'scanning' && styles.scanButtonScanning,
-              scanState === 'failed'   && styles.scanButtonFailed,
-            ]}
-            onPress={handleScan}
-            activeOpacity={0.85}
-            disabled={scanState === 'scanning'}
+            style={[styles.methodBtn, selectedMethod === 'face' && styles.methodBtnActive]}
+            onPress={() => switchMethod('face')}
+            activeOpacity={0.8}
           >
-            {scanState === 'scanning' ? (
-              <ActivityIndicator size={64} color={colors.textWhite} />
-            ) : (
-              <Ionicons name={getScanIcon()} size={80} color={getScanIconColor()} />
-            )}
+            <Ionicons
+              name="scan-outline"
+              size={20}
+              color={selectedMethod === 'face' ? AMBER : colors.textMuted}
+            />
+            <Text style={[styles.methodLabel, selectedMethod === 'face' && styles.methodLabelActive]}>
+              Face ID
+            </Text>
           </TouchableOpacity>
 
-          {/* Status hint text */}
-          {scanState === 'idle' && (
-            <Text style={styles.hintText}>
-              {selectedMethod === 'face' ? 'Tap to scan your face' : 'Tap to scan fingerprint'}
+          <TouchableOpacity
+            style={[styles.methodBtn, selectedMethod === 'fingerprint' && styles.methodBtnActive]}
+            onPress={() => switchMethod('fingerprint')}
+            activeOpacity={0.8}
+          >
+            <Ionicons
+              name="finger-print"
+              size={20}
+              color={selectedMethod === 'fingerprint' ? AMBER : colors.textMuted}
+            />
+            <Text style={[styles.methodLabel, selectedMethod === 'fingerprint' && styles.methodLabelActive]}>
+              Fingerprint
             </Text>
-          )}
-          {scanState === 'scanning' && (
-            <Text style={styles.hintText}>Scanning…</Text>
-          )}
-
-          {/* ── DEV MODE: Force Fail button ───────────────────────────────
-              Only shown in dev. Lets you trigger the failure path manually
-              without waiting for a random failed scan.
-              Remove this entire block before going to production.          */}
-          {DEV_MODE && scanState === 'idle' && (
-            <TouchableOpacity
-              style={styles.devFailBtn}
-              onPress={handleForceFail}
-              activeOpacity={0.8}
-            >
-              <Ionicons name="construct-outline" size={14} color={colors.warning} />
-              <Text style={styles.devFailText}>Force Fail (Dev)</Text>
-            </TouchableOpacity>
-          )}
-
-          {/* ── Failed state ─────────────────────────────────────────────────
-              Only shown after a failed scan — never during idle or scanning.
-              "Use PIN instead" goes to OfflineLoginScreen (PIN entry only).
-              Both online and offline use the same PIN screen.               */}
-          {scanState === 'failed' && (
-            <View style={styles.failedSection}>
-              <Text style={styles.errorText}>Scan failed — please try again.</Text>
-
-              {/* Retry the scan */}
-              <TouchableOpacity
-                style={styles.retryButton}
-                onPress={() => setScanState('idle')}
-              >
-                <Text style={styles.retryButtonText}>Retry</Text>
-              </TouchableOpacity>
-
-              {/* PIN fallback — navigates to PIN entry screen, NOT back to biometrics */}
-              <TouchableOpacity
-                style={styles.pinLink}
-                onPress={handleUsePIN}
-                activeOpacity={0.7}
-              >
-                <Ionicons name="keypad-outline" size={16} color={AMBER} />
-                <Text style={styles.pinLinkText}>Use PIN instead</Text>
-              </TouchableOpacity>
-
-            </View>
-          )}
-
-          {/* Quick method switch — only shown at idle, not after failure */}
-          {scanState === 'idle' && (
-            <TouchableOpacity
-              style={styles.switchLink}
-              onPress={() => switchMethod(selectedMethod === 'face' ? 'fingerprint' : 'face')}
-              activeOpacity={0.7}
-            >
-              <Text style={styles.switchLinkText}>
-                Use {selectedMethod === 'face' ? 'fingerprint' : 'Face ID'} instead
-              </Text>
-            </TouchableOpacity>
-          )}
-
+          </TouchableOpacity>
         </View>
+
+        {/* Large scan button */}
+        <TouchableOpacity
+          style={[
+            styles.scanButton,
+            scanState === 'scanning' && styles.scanButtonScanning,
+            scanState === 'failed'   && styles.scanButtonFailed,
+          ]}
+          onPress={handleScan}
+          activeOpacity={0.85}
+          disabled={scanState === 'scanning'}
+        >
+          {scanState === 'scanning' ? (
+            <ActivityIndicator size={64} color={colors.primary} />
+          ) : (
+            <Ionicons name={getScanIcon()} size={80} color={getScanIconColor()} />
+          )}
+        </TouchableOpacity>
+
+        {scanState === 'idle' && (
+          <Text style={styles.hintText}>
+            {selectedMethod === 'face' ? 'Tap to scan your face' : 'Tap to scan fingerprint'}
+          </Text>
+        )}
+        {scanState === 'scanning' && (
+          <Text style={styles.hintText}>Scanning…</Text>
+        )}
+
+        {/* DEV: Force Fail — remove entire block before production */}
+        {DEV_MODE && scanState === 'idle' && (
+          <TouchableOpacity style={styles.devFailBtn} onPress={handleForceFail} activeOpacity={0.8}>
+            <Ionicons name="construct-outline" size={14} color={colors.warning} />
+            <Text style={styles.devFailText}>Force Fail (Dev)</Text>
+          </TouchableOpacity>
+        )}
+
+        {/* Failed state — retry + PIN fallback */}
+        {scanState === 'failed' && (
+          <View style={styles.failedSection}>
+            <Text style={styles.errorText}>Scan failed — please try again.</Text>
+            <TouchableOpacity style={styles.retryButton} onPress={() => setScanState('idle')}>
+              <Text style={styles.retryButtonText}>Retry</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.pinLink} onPress={handleUsePIN} activeOpacity={0.7}>
+              <Ionicons name="keypad-outline" size={16} color={AMBER} />
+              <Text style={styles.pinLinkText}>Use PIN instead</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+
+      </View>
     </MainFrame>
   );
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Styles
-// ─────────────────────────────────────────────────────────────────────────────
 const styles = StyleSheet.create({
-  // ── Online/Offline pill — directly below SubHeader ───────────────────────
+  topWrap: { alignSelf: 'stretch' },
+
   statusPill: {
     flexDirection:     'row',
     alignItems:        'center',
@@ -290,20 +233,19 @@ const styles = StyleSheet.create({
     gap:               6,
     paddingVertical:   spacing.sm,
     borderBottomWidth: 1,
+    borderBottomColor: colors.border,
   },
   statusText: { fontFamily: fonts.bold, fontSize: fontSize.sm },
 
-  // ── Body ─────────────────────────────────────────────────────────────────
   body: {
-    flex:              1,
+    width:             '100%',
     alignItems:        'center',
-    justifyContent:    'flex-start',
     paddingHorizontal: spacing.lg,
     paddingTop:        spacing.xl * 1.5,
+    paddingBottom:     spacing.xl,
     gap:               spacing.md,
   },
 
-  // ── Prompt text — white ───────────────────────────────────────────────────
   promptText: {
     fontFamily:    fonts.bold,
     fontSize:      fontSize.lg,
@@ -313,7 +255,6 @@ const styles = StyleSheet.create({
     marginTop:     spacing.md,
   },
 
-  // ── Method toggle buttons ─────────────────────────────────────────────────
   methodRow: { flexDirection: 'row', gap: spacing.sm, marginTop: spacing.sm },
   methodBtn: {
     flexDirection:     'row',
@@ -333,7 +274,6 @@ const styles = StyleSheet.create({
   methodLabel:       { fontFamily: fonts.regular, fontSize: fontSize.sm, color: colors.textMuted },
   methodLabelActive: { fontFamily: fonts.bold, color: AMBER },
 
-  // ── Scan button ───────────────────────────────────────────────────────────
   scanButton: {
     width:           160,
     height:          160,
@@ -356,7 +296,6 @@ const styles = StyleSheet.create({
 
   hintText: { fontFamily: fonts.regular, fontSize: fontSize.sm, color: colors.textMuted },
 
-  // ── DEV force-fail button ─────────────────────────────────────────────────
   devFailBtn: {
     flexDirection:     'row',
     alignItems:        'center',
@@ -370,8 +309,7 @@ const styles = StyleSheet.create({
   },
   devFailText: { fontFamily: fonts.regular, fontSize: fontSize.xs, color: colors.warning },
 
-  // ── Failed section ────────────────────────────────────────────────────────
-  failedSection: { alignItems: 'center', gap: spacing.md },
+  failedSection:   { alignItems: 'center', gap: spacing.md },
   errorText: {
     fontFamily: fonts.regular,
     fontSize:   fontSize.sm,
@@ -389,21 +327,11 @@ const styles = StyleSheet.create({
   },
   retryButtonText: { fontFamily: fonts.bold, color: colors.textWhite, fontSize: fontSize.base },
 
-  // ── PIN link — only after failed scan ────────────────────────────────────
-  pinLink: { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: spacing.xs },
+  pinLink:     { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: spacing.xs },
   pinLinkText: {
     fontFamily:         fonts.bold,
     fontSize:           fontSize.sm,
     color:              AMBER,
-    textDecorationLine: 'underline',
-  },
-
-  // ── Switch method link — only at idle ────────────────────────────────────
-  switchLink: { marginTop: spacing.xs },
-  switchLinkText: {
-    fontFamily:         fonts.regular,
-    fontSize:           fontSize.sm,
-    color:              colors.textMuted,
     textDecorationLine: 'underline',
   },
 });

--- a/frontend/field-force-contractor/screens/LicenseScreen.tsx
+++ b/frontend/field-force-contractor/screens/LicenseScreen.tsx
@@ -1,9 +1,16 @@
-// LicenseScreen.tsx
+// LicenseScreen.tsx  —  Troy
 // Shows the contractor's license card with expandable detail rows.
 // Reached by tapping "License" on the Profile screen.
 //
-// The detail rows (Expiration, Role, Conditions, Tax Class) expand
-// and collapse when tapped, showing one at a time.
+// Uses MainFrame header="home" with Menu2 providing the back arrow
+// and "License Details" title. No SubHeader needed.
+//
+// ── LICENSE STATUS LOGIC ──────────────────────────────────────────────────────
+// Status is derived from the expiration date at runtime — never hardcoded:
+//   Expired        — past the expiration date                 (red)
+//   Expiring Soon  — within the next 30 days                  (amber)
+//   Active         — more than 30 days away                   (green)
+// ──────────────────────────────────────────────────────────────────────────────
 
 import { useState } from 'react';
 import {
@@ -11,210 +18,203 @@ import {
   Text,
   TouchableOpacity,
   StyleSheet,
+  StatusBar,
   Image,
 } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import { Ionicons }      from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+
 import { MainFrame } from '../components/MainFrame';
 import { colors, spacing, radius, fontSize, fonts } from '../constants/theme';
 
-// ---------------------------------------------------------------
-// Placeholder license data — replace with real data from your API
-// or pass it in via navigation params from the Profile screen
-// ---------------------------------------------------------------
+// ── Placeholder license data ──────────────────────────────────────────────────
 const MOCK_LICENSE = {
   name:       'John Doe',
   type:       'CITIZEN',
   licenseNo:  '25415236563',
-  status:     'Active',
   expiration: '01/20/2025',
   role:       'Contractor',
   conditions: 'None',
   taxClass:   '1099',
-  // This is a random public photo for testing — replace with the real contractor photo
   photoUri:   'https://randomuser.me/api/portraits/men/32.jpg',
 };
 
-// ---------------------------------------------------------------
-// DetailRow — one expandable row for a single license detail.
-// It shows just the label and a chevron arrow when closed.
-// When opened (isOpen = true), it also shows the value below.
-// ---------------------------------------------------------------
-// Defines the shape of the props (inputs) this component expects.
-// Pulling the type out here keeps the function signature clean and readable.
-type DetailRowProps = {
-  label:    string;
-  value:    string;
-  isOpen:   boolean;
-  onToggle: () => void;
-};
+const DEMO_ACTIVE_DATE = '12/31/2027';
 
-const DetailRow = (props: DetailRowProps) => {
-  return (
-    <TouchableOpacity style={rowStyles.container} onPress={props.onToggle} activeOpacity={0.8}>
+// ── License status helpers ────────────────────────────────────────────────────
+const EXPIRING_SOON_DAYS = 30;
+type LicenseStatus = 'Active' | 'Expiring Soon' | 'Expired';
 
-      {/* The always-visible header row with dot, label, and arrow */}
-      <View style={rowStyles.header}>
-        <View style={rowStyles.dot} />
-        <Text style={rowStyles.label}>{props.label}</Text>
-        {/* Arrow points forward when closed, up when open */}
-        <Ionicons
-          name={props.isOpen ? 'chevron-up' : 'chevron-forward'}
-          size={18}
-          color={colors.textMuted}
-        />
-      </View>
-
-      {/* The value only renders when this row is open */}
-      {props.isOpen && (
-        <Text style={rowStyles.value}>{props.value}</Text>
-      )}
-
-    </TouchableOpacity>
-  );
+function getLicenseStatus(expirationMMDDYYYY: string): LicenseStatus {
+  const [month, day, year] = expirationMMDDYYYY.split('/').map(Number);
+  const expDate = new Date(year, month - 1, day);
+  const today   = new Date();
+  today.setHours(0, 0, 0, 0);
+  expDate.setHours(0, 0, 0, 0);
+  const daysUntil = Math.ceil((expDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+  if (daysUntil < 0)                   return 'Expired';
+  if (daysUntil <= EXPIRING_SOON_DAYS) return 'Expiring Soon';
+  return 'Active';
 }
 
+function getDaysUntilExpiration(expirationMMDDYYYY: string): number {
+  const [month, day, year] = expirationMMDDYYYY.split('/').map(Number);
+  const expDate = new Date(year, month - 1, day);
+  const today   = new Date();
+  today.setHours(0, 0, 0, 0);
+  expDate.setHours(0, 0, 0, 0);
+  return Math.ceil((expDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+function getStatusColor(status: LicenseStatus): string {
+  if (status === 'Expired')       return colors.error;
+  if (status === 'Expiring Soon') return colors.warning;
+  return colors.success;
+}
+
+// ── DetailRow ─────────────────────────────────────────────────────────────────
+type DetailRowProps = { label: string; value: string; isOpen: boolean; onToggle: () => void; };
+
+const DetailRow = (props: DetailRowProps) => (
+  <TouchableOpacity style={rowStyles.container} onPress={props.onToggle} activeOpacity={0.8}>
+    <View style={rowStyles.header}>
+      <View style={rowStyles.dot} />
+      <Text style={rowStyles.label}>{props.label}</Text>
+      <Ionicons name={props.isOpen ? 'chevron-up' : 'chevron-forward'} size={18} color={colors.textMuted} />
+    </View>
+    {props.isOpen && <Text style={rowStyles.value}>{props.value}</Text>}
+  </TouchableOpacity>
+);
+
 const rowStyles = StyleSheet.create({
-  container: {
-    backgroundColor:   colors.card,
-    borderRadius:      radius.md,
-    borderWidth:       1,
-    borderColor:       colors.border,
-    paddingVertical:   14,
-    paddingHorizontal: spacing.md,
-    gap:               spacing.xs,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems:    'center',
-    gap:           spacing.sm,
-  },
-  dot: {
-    width:           8,
-    height:          8,
-    borderRadius:    4, // makes the square into a circle
-    backgroundColor: colors.textMuted,
-  },
-  label: { flex: 1, fontFamily: fonts.regular, fontSize: fontSize.base, color: colors.textWhite },
-  value: {
-    fontFamily: fonts.regular,
-    fontSize:   fontSize.sm,
-    color:      colors.textMuted,
-    paddingLeft: 20, // indents the value to align under the label
-    marginTop:  spacing.xs,
-  },
+  container: { backgroundColor: colors.card, borderRadius: radius.md, borderWidth: 1, borderColor: colors.border, paddingVertical: 14, paddingHorizontal: spacing.md, gap: spacing.xs },
+  header:    { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
+  dot:       { width: 8, height: 8, borderRadius: 4, backgroundColor: colors.textMuted },
+  label:     { flex: 1, fontFamily: fonts.regular, fontSize: fontSize.base, color: colors.textWhite },
+  value:     { fontFamily: fonts.regular, fontSize: fontSize.sm, color: colors.textMuted, paddingLeft: 20, marginTop: spacing.xs },
 });
 
-// ---------------------------------------------------------------
-// Main LicenseScreen component
-// ---------------------------------------------------------------
+// ── LicenseScreen ─────────────────────────────────────────────────────────────
 export default function LicenseScreen() {
-  // Tracks which row is currently open. null means all are closed.
-  // We store the row's key (a string) so we know which one to expand.
-  const [openRow, setOpenRow] = useState<string | null>(null);
+  const navigation = useNavigation<any>();
 
-  // If the tapped row is already open, close it. Otherwise open it.
-  // This ensures only one row is open at a time.
-  const toggleRow = (key: string) => {
-    if (openRow === key) {
-      setOpenRow(null); // close it
-    } else {
-      setOpenRow(key);  // open this one
-    }
-  }
+  const [openRow,       setOpenRow]       = useState<string | null>(null);
+  const [showingActive, setShowingActive] = useState(false);
+
+  const currentExpiration = showingActive ? DEMO_ACTIVE_DATE : MOCK_LICENSE.expiration;
+  const licenseStatus     = getLicenseStatus(currentExpiration);
+  const daysUntilExp      = getDaysUntilExpiration(currentExpiration);
+  const statusColor       = getStatusColor(licenseStatus);
+  const showWarning       = licenseStatus === 'Expired' || licenseStatus === 'Expiring Soon';
+
+  const toggleRow = (key: string) => setOpenRow(prev => (prev === key ? null : key));
 
   return (
-    <MainFrame header="home">
-      <View style={styles.scrollContent}>
+    <MainFrame header="home" headerMenu={['Menu2', ['License Details']]}>
+      <StatusBar barStyle="light-content" backgroundColor="transparent" translucent />
 
-        {/* ── License card ─────────────────────────────────── */}
-        <View style={styles.licenseCard}>
-
-          {/* Contractor photo on the left */}
-          <Image
-            source={{ uri: MOCK_LICENSE.photoUri }}
-            style={styles.photo}
+      {/* Warning banner — only shown when expired or expiring soon */}
+      {showWarning && (
+        <View style={[
+          styles.warningBanner,
+          {
+            borderColor:     statusColor,
+            backgroundColor: licenseStatus === 'Expired'
+              ? 'rgba(248,113,113,0.10)'
+              : 'rgba(245,158,11,0.10)',
+          },
+        ]}>
+          <Ionicons
+            name={licenseStatus === 'Expired' ? 'close-circle-outline' : 'warning-outline'}
+            size={18}
+            color={statusColor}
           />
+          <Text style={[styles.warningText, { color: statusColor }]}>
+            {licenseStatus === 'Expired'
+              ? `Your license expired ${Math.abs(daysUntilExp)} day${Math.abs(daysUntilExp) === 1 ? '' : 's'} ago. Contact your vendor to renew.`
+              : `Your license expires in ${daysUntilExp} day${daysUntilExp === 1 ? '' : 's'}. Renew soon to avoid disruption.`
+            }
+          </Text>
+        </View>
+      )}
 
-          {/* License info on the right */}
-          <View style={styles.cardInfo}>
-            <Text style={styles.cardName}>{MOCK_LICENSE.name}</Text>
-            <Text style={styles.cardType}>{MOCK_LICENSE.type}</Text>
-
-            {/* License number — orange label above, white number below */}
-            <Text style={styles.licenseLabel}>License No.</Text>
-            <Text style={styles.licenseNumber}>{MOCK_LICENSE.licenseNo}</Text>
-
-            {/* Status shown in green to indicate active */}
-            <View style={styles.statusRow}>
-              <Text style={styles.statusLabel}>Status </Text>
-              <Text style={styles.statusValue}>{MOCK_LICENSE.status}</Text>
-            </View>
+      {/* License card */}
+      <View style={styles.licenseCard}>
+        <Image source={{ uri: MOCK_LICENSE.photoUri }} style={styles.photo} />
+        <View style={styles.cardInfo}>
+          <Text style={styles.cardName}>{MOCK_LICENSE.name}</Text>
+          <Text style={styles.cardType}>{MOCK_LICENSE.type}</Text>
+          <Text style={styles.licenseLabel}>License No.</Text>
+          <Text style={styles.licenseNumber}>{MOCK_LICENSE.licenseNo}</Text>
+          <View style={styles.statusRow}>
+            <Text style={styles.statusLabel}>Status </Text>
+            <Text style={[styles.statusValue, { color: statusColor }]}>{licenseStatus}</Text>
           </View>
         </View>
-
-        {/* ── Expandable detail rows ────────────────────────── */}
-        <View style={styles.detailsList}>
-          <DetailRow
-            label="Expiration"
-            value={MOCK_LICENSE.expiration}
-            isOpen={openRow === 'expiration'}
-            onToggle={() => toggleRow('expiration')}
-          />
-          <DetailRow
-            label="Role"
-            value={MOCK_LICENSE.role}
-            isOpen={openRow === 'role'}
-            onToggle={() => toggleRow('role')}
-          />
-          <DetailRow
-            label="Conditions"
-            value={MOCK_LICENSE.conditions}
-            isOpen={openRow === 'conditions'}
-            onToggle={() => toggleRow('conditions')}
-          />
-          <DetailRow
-            label="Tax Class"
-            value={MOCK_LICENSE.taxClass}
-            isOpen={openRow === 'taxClass'}
-            onToggle={() => toggleRow('taxClass')}
-          />
-        </View>
-
       </View>
+
+      {/* Expandable detail rows */}
+      <View style={styles.detailsList}>
+        <DetailRow label="Expiration" value={currentExpiration} isOpen={openRow === 'expiration'} onToggle={() => toggleRow('expiration')} />
+        <DetailRow label="Role"       value={MOCK_LICENSE.role}       isOpen={openRow === 'role'}       onToggle={() => toggleRow('role')} />
+        <DetailRow label="Conditions" value={MOCK_LICENSE.conditions} isOpen={openRow === 'conditions'} onToggle={() => toggleRow('conditions')} />
+        <DetailRow label="Tax Class"  value={MOCK_LICENSE.taxClass}   isOpen={openRow === 'taxClass'}   onToggle={() => toggleRow('taxClass')} />
+      </View>
+
+      {/* Dev toggle button */}
+      <TouchableOpacity
+        style={styles.devToggleBtn}
+        onPress={() => setShowingActive(prev => !prev)}
+        activeOpacity={0.8}
+      >
+        <Ionicons name="construct-outline" size={14} color={colors.warning} />
+        <Text style={styles.devToggleText}>
+          Toggle Status (Dev) — showing:{' '}
+          <Text style={{ fontFamily: fonts.bold }}>{showingActive ? 'Active' : 'Expired'}</Text>
+        </Text>
+      </TouchableOpacity>
+
     </MainFrame>
   );
 }
 
 const styles = StyleSheet.create({
-  scrollContent: { gap: spacing.md, paddingBottom: spacing.xl },
+  warningBanner: {
+    flexDirection: 'row', alignItems: 'flex-start', gap: spacing.sm,
+    borderWidth: 1, borderRadius: radius.md, padding: spacing.md,
+    marginHorizontal: spacing.md, marginTop: spacing.md,
+    width: '100%', maxWidth: 480, alignSelf: 'center',
+  },
+  warningText: { flex: 1, fontFamily: fonts.regular, fontSize: fontSize.sm, lineHeight: 20 },
 
-  // The card at the top with photo + license info
   licenseCard: {
-    flexDirection:    'row',
-    backgroundColor:  '#0f1d33',
-    marginHorizontal: spacing.md,
-    marginTop:        spacing.md,
-    borderRadius:     radius.lg,
-    padding:          spacing.md,
-    gap:              spacing.md,
-    borderWidth:      1,
-    borderColor:      colors.border,
+    flexDirection: 'row', backgroundColor: '#0f1d33',
+    marginHorizontal: spacing.md, marginTop: spacing.md,
+    borderRadius: radius.lg, padding: spacing.md, gap: spacing.md,
+    borderWidth: 1, borderColor: colors.border,
+    width: '100%', maxWidth: 480, alignSelf: 'center',
   },
-  photo: {
-    width:           70,
-    height:          70,
-    borderRadius:    8,
-    backgroundColor: colors.cardAlt, // shown as a gray box if the image fails to load
-  },
-  cardInfo:     { flex: 1, gap: 2 },
-  cardName:     { fontFamily: fonts.bold,    fontSize: fontSize.lg, color: colors.textWhite },
-  cardType:     { fontFamily: fonts.regular, fontSize: fontSize.sm, color: colors.textLight, marginBottom: 6 },
-  licenseLabel: { fontFamily: fonts.regular, fontSize: fontSize.xs, color: colors.primary },
-  licenseNumber: { fontFamily: fonts.bold,   fontSize: fontSize.sm, color: colors.textWhite, marginBottom: 4 },
-  statusRow:    { flexDirection: 'row', alignItems: 'center' },
-  statusLabel:  { fontFamily: fonts.regular, fontSize: fontSize.sm, color: colors.textLight },
-  statusValue:  { fontFamily: fonts.bold,    fontSize: fontSize.sm, color: colors.success }, // green
+  photo:         { width: 70, height: 70, borderRadius: 8, backgroundColor: colors.cardAlt },
+  cardInfo:      { flex: 1, gap: 2 },
+  cardName:      { fontFamily: fonts.bold,    fontSize: fontSize.lg, color: colors.textWhite },
+  cardType:      { fontFamily: fonts.regular, fontSize: fontSize.sm, color: colors.textLight, marginBottom: 6 },
+  licenseLabel:  { fontFamily: fonts.regular, fontSize: fontSize.xs, color: colors.primary },
+  licenseNumber: { fontFamily: fonts.bold,    fontSize: fontSize.sm, color: colors.textWhite, marginBottom: 4 },
+  statusRow:     { flexDirection: 'row', alignItems: 'center' },
+  statusLabel:   { fontFamily: fonts.regular, fontSize: fontSize.sm, color: colors.textLight },
+  statusValue:   { fontFamily: fonts.bold,    fontSize: fontSize.sm },
 
-  // The list of expandable rows below the card
-  detailsList: { gap: spacing.sm, paddingHorizontal: spacing.md },
+  detailsList: {
+    gap: spacing.sm, paddingHorizontal: spacing.md,
+    width: '100%', maxWidth: 480, alignSelf: 'center', marginTop: spacing.md,
+  },
+
+  devToggleBtn: {
+    flexDirection: 'row', alignItems: 'center', gap: 6,
+    alignSelf: 'center', marginTop: spacing.xl, marginBottom: spacing.md,
+    paddingVertical: spacing.sm, paddingHorizontal: spacing.md,
+    borderRadius: radius.sm, borderWidth: 1,
+    borderColor: colors.warning, backgroundColor: 'rgba(245,158,11,0.08)',
+  },
+  devToggleText: { fontFamily: fonts.regular, fontSize: fontSize.xs, color: colors.warning },
 });

--- a/frontend/field-force-contractor/screens/LoginScreen.tsx
+++ b/frontend/field-force-contractor/screens/LoginScreen.tsx
@@ -6,8 +6,13 @@
 //   • SplashScreenBackGround.png background
 //   • ff-logo-name.png centered header bar (status-bar spacing handled by MainFrame)
 //   • No header/footer menus — user isn't authenticated yet
+//
+// ── AUTH FLOW FIX ──────────────────────────────────────────────────────────────
+// login() is NOT called here. Token + user are passed as nav params to
+// BiometricCheck, which calls login() only after a successful scan.
+// ──────────────────────────────────────────────────────────────────────────────
 
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import {
   View,
   Text,
@@ -27,27 +32,17 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { MainFrame }          from '../components/MainFrame';
 import { RootStackParamList } from '@/App';
 import { colors, spacing, radius, fontSize, fonts } from '../constants/theme';
-import { api, pingServer, LoginResponse, ApiError } from '../utils/api';
-import { useAuth }            from '../contexts/AuthContext';
+import { api, LoginResponse, ApiError } from '../utils/api';
 
-// This tells TypeScript what screen we're on so navigation.navigate()
-// knows which screens are valid to go to from here
 type Nav = NativeStackNavigationProp<RootStackParamList, 'Login'>;
 
 // ─────────────────────────────────────────────────────────────────────────────
-// ⚙️  STAKEHOLDER CONFIG — change this one line if the policy shifts
-//
-//   'email'    = contractor logs in with their email address only
-//   'username' = contractor logs in with a username only
-//   'either'   = single field accepts email OR username (current default)
-//
-// The backend /auth/login endpoint detects '@' and looks up the correct
-// column, so all three options send the same `identifier` key over the wire.
+// ⚙️  STAKEHOLDER CONFIG
+//   'email'    = contractor logs in with their email address
+//   'username' = contractor logs in with a username / email (accepted by backend)
 // ─────────────────────────────────────────────────────────────────────────────
-const LOGIN_FIELD: 'email' | 'username' | 'either' = 'either';
+const LOGIN_FIELD: 'email' | 'username' = 'username';
 
-// Labels, placeholder text, and keyboard type are all derived from the flag above
-// so only the one line above ever needs to change — nothing else in this file
 const FIELD_CONFIG = {
   email: {
     label:          'Email Address',
@@ -56,16 +51,8 @@ const FIELD_CONFIG = {
     autoCapitalize: 'none' as const,
   },
   username: {
-    label:          'Username',
-    placeholder:    'Enter your username',
-    keyboardType:   'default' as const,
-    autoCapitalize: 'none' as const,
-  },
-  // 'either' — single field mode. Default keyboard since we can't assume
-  // they'll type an email; email-address keyboard would hide the period key.
-  either: {
-    label:          'Username',
-    placeholder:    'Username',
+    label:          'Username or Email',
+    placeholder:    'Enter your username or email',
     keyboardType:   'default' as const,
     autoCapitalize: 'none' as const,
   },
@@ -74,88 +61,55 @@ const FIELD_CONFIG = {
 const fieldConfig = FIELD_CONFIG[LOGIN_FIELD];
 
 // ─────────────────────────────────────────────────────────────────────────────
-// ⚙️  DEV MODE — set this to true to bypass the real API call while testing.
-//
-//  When DEV_MODE is true:
-//    • Any non-empty username + password (6+ chars) will succeed immediately
-//    • No network request is made — the connection timeout error disappears
-//    • The app routes correctly based on the Online/Offline pill state
-//
-//  Set to false when the backend is ready and you want real API calls.
+// ⚙️  DEV MODE
+//  true  = any non-empty username + password (6+ chars) succeeds immediately.
+//  Set to false when the backend is ready.
 // ─────────────────────────────────────────────────────────────────────────────
-const DEV_MODE = false;
+const DEV_MODE = true;
 
-// A simple function to check if an email looks valid.
-// It uses a "regex" (regular expression) to check the format.
-// Only used when LOGIN_FIELD === 'email'.
 const isValidEmail = (value: string) => {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return emailRegex.test(value.trim());
 };
 
+const AMBER = '#f59e0b';
+
 // ─────────────────────────────────────────────────────────────────────────────
 export default function LoginScreen() {
   const navigation = useNavigation<Nav>();
-  const { login }  = useAuth();
 
-  // useState stores values that can change. When they change, the screen re-renders.
-  const [identifier,   setIdentifier]   = useState(''); // holds email OR username depending on LOGIN_FIELD
+  const [identifier,   setIdentifier]   = useState('');
   const [password,     setPassword]     = useState('');
-  const [showPassword, setShowPassword] = useState(false); // toggles the eye icon
-  const [isSubmitting,      setIsSubmitting]      = useState(false); // shows spinner on button
-  // Flips to true if login is taking longer than ~8s — usually means Render
-  // is cold-starting and we want to reassure the user it's not hanging.
-  const [isSlowConnection,  setIsSlowConnection]  = useState(false);
-  const slowTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [showPassword, setShowPassword] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isOffline,    setIsOffline]    = useState(false);
 
-  // Wake the Render free-tier backend up as soon as the login screen mounts,
-  // so by the time the user finishes typing their credentials the server is
-  // (hopefully) already warm. Fire-and-forget — errors are ignored.
-  useEffect(() => {
-    pingServer();
-    return () => {
-      if (slowTimerRef.current) clearTimeout(slowTimerRef.current);
-    };
-  }, []);
-
-  // Online/Offline toggle — this is a UI state indicator used for testing.
-  // Tapping the pill just flips this value. It does NOT navigate by itself.
-  // The Login button uses this to decide where to route after a successful login:
-  //   Online  → BiometricCheck (normal flow)
-  //   Offline → OfflineLogin   (PIN-based flow)
-  const [isOffline, setIsOffline] = useState(false);
-
-  // These hold error messages. Empty string '' means no error to show.
   const [identifierError, setIdentifierError] = useState('');
   const [passwordError,   setPasswordError]   = useState('');
-  const [loginError,      setLoginError]      = useState(''); // shown when credentials are wrong
+  const [loginError,      setLoginError]      = useState('');
 
-  // ── Validation ───────────────────────────────────────────────────────────
+  // ── Validation ─────────────────────────────────────────────────────────────
 
-  // This runs when the user taps away from the identifier field (on blur)
   const validateIdentifier = () => {
     if (identifier.trim() === '') {
       setIdentifierError(`Please enter your ${fieldConfig.label.toLowerCase()}.`);
     } else if (LOGIN_FIELD === 'email' && !isValidEmail(identifier)) {
       setIdentifierError('Please enter a valid email address (e.g. name@example.com).');
     } else {
-      setIdentifierError(''); // clear any previous error if it's valid now
+      setIdentifierError('');
     }
   };
 
-  // This runs when the user taps away from the password field
   const validatePassword = () => {
     if (password === '') {
       setPasswordError('Please enter your password.');
     } else if (password.length < 6) {
       setPasswordError('Password must be at least 6 characters.');
     } else {
-      setPasswordError(''); // clear error
+      setPasswordError('');
     }
   };
 
-  // When the user changes the identifier field, clear any errors so they
-  // don't see stale error messages while they're still typing
   const handleIdentifierChange = (newValue: string) => {
     setIdentifier(newValue);
     setIdentifierError('');
@@ -168,14 +122,9 @@ export default function LoginScreen() {
     setLoginError('');
   };
 
-  // ── Submit ───────────────────────────────────────────────────────────────
+  // ── Submit ──────────────────────────────────────────────────────────────────
 
-  // This runs when the user taps the Login button.
-  // After a successful login it routes based on the Online/Offline pill:
-  //   Online  → BiometricCheck
-  //   Offline → OfflineLogin
   const handleLogin = async () => {
-    // First check if both fields are valid before doing anything
     let everythingIsValid = true;
 
     if (identifier.trim() === '') {
@@ -198,41 +147,31 @@ export default function LoginScreen() {
       setPasswordError('');
     }
 
-    // If either field has an error, stop here and don't try to log in
     if (!everythingIsValid) return;
 
     setIsSubmitting(true);
     setLoginError('');
-    setIsSlowConnection(false);
-    // If the call is still running after 8s, assume Render is cold-starting
-    // and show a gentle "waking server up" message so the user doesn't bail.
-    slowTimerRef.current = setTimeout(() => setIsSlowConnection(true), 8_000);
 
     try {
       if (DEV_MODE) {
-        // ── DEV MODE: skip the real API call ──────────────────────────────
-        // Simulate a short network delay so the spinner is visible
         await new Promise(resolve => setTimeout(resolve, 800));
-
-        // Both online and offline go to biometrics first.
-        // If biometrics fail, BiometricScreen routes to the PIN screen.
-        navigation.navigate('BiometricCheck');
+        navigation.navigate('BiometricCheck', {
+          pendingToken: 'dev-token',
+          pendingUser:  { id: 0, username: identifier.trim(), role: 'contractor' },
+        });
         return;
       }
 
-      // ── PRODUCTION: call the real backend /auth/login endpoint ────────
-      // Always send `identifier` — the backend detects whether it's an email
-      // or username based on the '@' character and picks the right column.
       const res = await api.post<LoginResponse>('/auth/login', {
         identifier: identifier.trim(),
         password,
       });
 
-      // Store JWT + user info in AuthContext (persists to SecureStore)
-      await login(res.token, res.user);
-
-      // Both online and offline go to biometrics first.
-      navigation.navigate('BiometricCheck');
+      // Do NOT call login() here — BiometricCheck calls it after scan succeeds
+      navigation.navigate('BiometricCheck', {
+        pendingToken: res.token,
+        pendingUser:  res.user,
+      });
 
     } catch (err) {
       const apiErr = err as ApiError;
@@ -244,49 +183,33 @@ export default function LoginScreen() {
         setLoginError(apiErr.error || 'Something went wrong. Please try again.');
       }
     } finally {
-      if (slowTimerRef.current) {
-        clearTimeout(slowTimerRef.current);
-        slowTimerRef.current = null;
-      }
       setIsSubmitting(false);
-      setIsSlowConnection(false);
     }
   };
 
-  // The Login button should look "active" only when both fields look valid
   const formLooksReady =
     identifier.trim().length > 0 &&
     (LOGIN_FIELD === 'email' ? isValidEmail(identifier) : true) &&
     password.length >= 6;
 
-  // ─────────────────────────────────────────────────────────────────────────
-  // Render
-  // ─────────────────────────────────────────────────────────────────────────
+  // ── Render ──────────────────────────────────────────────────────────────────
+
   return (
     <MainFrame header="default" headerMenu={['none']} footerMenu={['none']}>
 
-      {/* Makes the status bar text white so it's visible on our dark background */}
       <StatusBar barStyle="light-content" backgroundColor="transparent" translucent />
 
-      {/* KeyboardAvoidingView pushes the form up when the keyboard opens
-          so the inputs don't get hidden behind it */}
       <KeyboardAvoidingView
         style={styles.kav}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       >
         <ScrollView
           contentContainerStyle={styles.scroll}
-          keyboardShouldPersistTaps="handled" // lets buttons work even if keyboard is open
+          keyboardShouldPersistTaps="handled"
           showsVerticalScrollIndicator={false}
         >
 
-          {/* Online/Offline status pill ─────────────────────────────────────
-              This is a VISUAL TOGGLE ONLY — tapping it flips the pill between
-              Online (green) and Offline (amber) so you can test both flows.
-              It does NOT navigate anywhere by itself.
-              The Login button reads this state and routes accordingly:
-                Online  → BiometricCheck
-                Offline → OfflineLogin                                       */}
+          {/* Online/Offline status pill — visual toggle only for testing */}
           <TouchableOpacity
             style={styles.statusPill}
             onPress={() => setIsOffline(!isOffline)}
@@ -302,25 +225,22 @@ export default function LoginScreen() {
             </Text>
           </TouchableOpacity>
 
-          {/* Generic person icon — in production this could show the user's photo */}
+          {/* Avatar */}
           <View style={styles.avatarCircle}>
             <Ionicons name="person" size={52} color="#8a9bb8" />
           </View>
 
-          {/* App branding */}
+          {/* Branding — "Field Force" title removed since the header already shows it.
+              "Contractor Portal" is promoted to be the main headline so it is clear
+              what this login page is for. "Restricted Access" stays in amber below. */}
           <View style={styles.brandBlock}>
-            <Text style={styles.brandTitle}>Field Force</Text>
-            <View style={styles.brandLine} />
-            <Text style={styles.brandSub}>Contractor Portal</Text>
-            {/* Amber color draws attention to "Restricted Access" — matches Troy's mockup */}
+            <Text style={styles.brandPortal}>Contractor Portal</Text>
             <Text style={styles.brandRestricted}>Restricted Access</Text>
           </View>
 
-          {/* The login form */}
+          {/* Form */}
           <View style={styles.form}>
 
-            {/* This red banner only shows up when the wrong credentials are entered.
-                It stays hidden (renders nothing) when loginError is an empty string. */}
             {loginError !== '' && (
               <View style={styles.errorBanner}>
                 <Ionicons name="alert-circle-outline" size={18} color={colors.error} />
@@ -328,42 +248,20 @@ export default function LoginScreen() {
               </View>
             )}
 
-            {/* Cold-start notice: Render free tier sleeps after ~15 min idle.
-                We show this after the login has been pending for 8s to reassure
-                the user that the spinner isn't stuck. */}
-            {isSlowConnection && loginError === '' && (
-              <View style={styles.errorBanner}>
-                <ActivityIndicator size="small" color={colors.primary} />
-                <Text style={styles.errorBannerText}>
-                  Waking server up — first login after idle can take up to a minute.
-                </Text>
-              </View>
-            )}
-
-            {/* Email / Username input — behavior controlled by LOGIN_FIELD at the top */}
+            {/* Username / Email input — orange placeholder, no label above */}
             <View style={styles.fieldGroup}>
-              <View>
-                <TextInput
-                  style={[
-                    styles.input,
-                    identifier !== '' && styles.inputFilled,
-                    identifierError !== '' ? styles.inputError : null, // red border if error
-                  ]}
-                  value={identifier}
-                  onChangeText={handleIdentifierChange}
-                  onBlur={validateIdentifier} // validate when they leave the field
-                  placeholder=""
-                  keyboardType={fieldConfig.keyboardType}
-                  autoCapitalize={fieldConfig.autoCapitalize}
-                  autoCorrect={false}
-                />
-                {identifier === '' && (
-                  <Text style={styles.neonPlaceholder} pointerEvents="none">
-                    {fieldConfig.placeholder}
-                  </Text>
-                )}
-              </View>
-              {/* Only shows the error text if there is one */}
+              <TextInput
+                style={[styles.input, identifierError !== '' ? styles.inputError : null]}
+                value={identifier}
+                onChangeText={handleIdentifierChange}
+                onBlur={validateIdentifier}
+                placeholder="Username"
+                placeholderTextColor={AMBER}
+                keyboardType={fieldConfig.keyboardType}
+                autoCapitalize={fieldConfig.autoCapitalize}
+                autoCorrect={false}
+                accessibilityLabel="Username or email"
+              />
               {identifierError !== '' && (
                 <View style={styles.fieldErrorRow}>
                   <Ionicons name="alert-circle-outline" size={14} color={colors.error} />
@@ -372,31 +270,25 @@ export default function LoginScreen() {
               )}
             </View>
 
-            {/* Password input */}
+            {/* Password input — orange placeholder, no label above */}
             <View style={styles.fieldGroup}>
-              {/* We wrap the input in a View so we can position the eye icon on top of it */}
               <View>
                 <TextInput
                   style={[
                     styles.input,
-                    styles.inputPadRight, // extra right padding so text doesn't overlap the eye icon
-                    password !== '' && styles.inputFilled,
+                    styles.inputPadRight,
                     passwordError !== '' ? styles.inputError : null,
                   ]}
                   value={password}
                   onChangeText={handlePasswordChange}
                   onBlur={validatePassword}
-                  placeholder=""
-                  secureTextEntry={!showPassword} // hides/shows the password text
+                  placeholder="Password"
+                  placeholderTextColor={AMBER}
+                  secureTextEntry={!showPassword}
                   autoCapitalize="none"
                   autoCorrect={false}
+                  accessibilityLabel="Password"
                 />
-                {password === '' && (
-                  <Text style={styles.neonPlaceholder} pointerEvents="none">
-                    Password
-                  </Text>
-                )}
-                {/* Eye icon button — toggles between showing and hiding the password */}
                 <TouchableOpacity
                   style={styles.eyeBtn}
                   onPress={() => setShowPassword(!showPassword)}
@@ -416,12 +308,15 @@ export default function LoginScreen() {
               )}
             </View>
 
-            {/* Login button — appears grayed out when the form isn't ready or submitting */}
+            {/* Login button — amber when ready, gray when not */}
             <TouchableOpacity
-              style={[styles.loginBtn, (!formLooksReady || isSubmitting) && styles.btnDisabled]}
+              style={[
+                styles.loginBtn,
+                formLooksReady && !isSubmitting ? styles.loginBtnActive : styles.loginBtnDisabled,
+              ]}
               onPress={handleLogin}
               activeOpacity={0.85}
-              disabled={isSubmitting}
+              disabled={!formLooksReady || isSubmitting}
             >
               {isSubmitting ? (
                 <ActivityIndicator color={colors.textWhite} />
@@ -430,14 +325,12 @@ export default function LoginScreen() {
               )}
             </TouchableOpacity>
 
-            {/* Visual separator between Login and Forgot Password */}
             <View style={styles.dividerRow}>
               <View style={styles.dividerLine} />
               <Text style={styles.dividerText}>OR</Text>
               <View style={styles.dividerLine} />
             </View>
 
-            {/* Takes user to the password reset screen */}
             <TouchableOpacity
               style={styles.secondaryBtn}
               onPress={() => navigation.navigate('PasswordReset')}
@@ -455,14 +348,10 @@ export default function LoginScreen() {
   );
 }
 
-// All the styles for this screen live here.
-// We keep styles at the bottom so the component logic above is easier to read.
-const AMBER = '#f59e0b'; // Login button + "Restricted Access" — matches Troy's approved mockup
-
 const styles = StyleSheet.create({
   kav:   { flex: 1, width: '100%' },
   scroll: {
-    flexGrow:          1,       // lets the ScrollView expand to fill available space
+    flexGrow:          1,
     alignItems:        'center',
     paddingHorizontal: spacing.lg,
     paddingBottom:     spacing.xl,
@@ -474,82 +363,60 @@ const styles = StyleSheet.create({
     marginTop:     spacing.lg,
     marginBottom:  spacing.md,
   },
-  statusText: { fontFamily: fonts.bold, fontSize: fontSize.sm },
+  statusText:   { fontFamily: fonts.bold, fontSize: fontSize.sm },
   avatarCircle: {
     width:           100,
     height:          100,
-    borderRadius:    50,        // makes the square a circle
+    borderRadius:    50,
     backgroundColor: '#1e2d45',
     alignItems:      'center',
     justifyContent:  'center',
     marginBottom:    spacing.md,
   },
-  brandBlock:  { alignItems: 'center', marginBottom: spacing.lg },
-  brandTitle: {
-    fontFamily:    fonts.boldItalic,
-    fontSize:      28,
+
+  // Branding — "Contractor Portal" is now the headline
+  brandBlock: { alignItems: 'center', marginBottom: spacing.lg },
+  brandPortal: {
+    fontFamily:    fonts.bold,
+    fontSize:      26,              // larger than before
     color:         colors.textWhite,
-    letterSpacing: 1,
-  },
-  brandLine: {
-    width:           '70%',
-    height:          2,
-    backgroundColor: colors.textWhite,
-    marginVertical:  6,
-  },
-  brandSub: {
-    fontFamily:   fonts.regular,
-    fontSize:     fontSize.base,
-    color:        colors.textLight,
-    marginBottom: 4,
+    letterSpacing: 0.5,
+    marginBottom:  spacing.xs,
   },
   brandRestricted: {
     fontFamily: fonts.bold,
     fontSize:   fontSize.sm,
-    color:      AMBER,           // amber — draws attention to "Restricted Access"
+    color:      '#f59e0b',
   },
+
   form:       { width: '100%', maxWidth: 380, gap: spacing.md },
   fieldGroup: { gap: 6 },
-  label:      { fontFamily: fonts.regular, fontSize: fontSize.sm, color: colors.textLight },
+
+  // Darker input background, orange border and placeholder
   input: {
     width:             '100%',
-    backgroundColor:   colors.card,
+    backgroundColor:   '#0d1520',
     borderRadius:      radius.md,
     borderWidth:       1,
-    borderColor:       colors.border,
+    borderColor:       '#f59e0b',
     paddingHorizontal: spacing.md,
     paddingVertical:   14,
     fontFamily:        fonts.regular,
     color:             colors.textWhite,
     fontSize:          fontSize.base,
   },
-  inputFilled:   { backgroundColor: 'rgba(10,14,26,0.8)' }, // darkens when user starts typing
-  neonPlaceholder: {
-    position:          'absolute',
-    left:              16,
-    top:               14,
-    fontFamily:        fonts.regular,
-    fontSize:          fontSize.base,
-    color:             '#ff8c00',
-    textShadowColor:   'rgba(255,140,0,0.9)',
-    textShadowOffset:  { width: 0, height: 0 },
-    textShadowRadius:  10,
-  },
-  inputError:    { borderColor: colors.error }, // overrides the default border with red
-  inputPadRight: { paddingRight: 48 },           // keeps text from going under the eye button
+  inputError:    { borderColor: colors.error },
+  inputPadRight: { paddingRight: 48 },
   eyeBtn:        { position: 'absolute', right: 14, top: 14 },
-  fieldErrorRow: {
-    flexDirection: 'row',
-    alignItems:    'center',
-    gap:           5,
-    marginTop:     2,
-  },
+
+  fieldErrorRow: { flexDirection: 'row', alignItems: 'center', gap: 5, marginTop: 2 },
   fieldErrorText: {
     fontFamily: fonts.regular,
     fontSize:   fontSize.xs,
     color:      colors.error,
     flex:       1,
   },
+
   errorBanner: {
     flexDirection:   'row',
     alignItems:      'flex-start',
@@ -567,23 +434,21 @@ const styles = StyleSheet.create({
     flex:       1,
     lineHeight: 20,
   },
-  loginBtn: {
-    backgroundColor: AMBER,     // amber fill — matches Troy's approved mockup
-    borderRadius:    radius.md,
-    paddingVertical: 15,
-    alignItems:      'center',
-    marginTop:       spacing.sm,
-  },
-  btnDisabled:  { backgroundColor: colors.cardAlt }, // grayed out state
+
+  loginBtn:         { borderRadius: radius.md, paddingVertical: 15, alignItems: 'center', marginTop: spacing.sm },
+  loginBtnActive:   { backgroundColor: '#f59e0b' },
+  loginBtnDisabled: { backgroundColor: colors.cardAlt },
   loginBtnText: {
     fontFamily:    fonts.bold,
     color:         colors.textWhite,
     fontSize:      fontSize.base,
     letterSpacing: 0.5,
   },
+
   dividerRow:  { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
   dividerLine: { flex: 1, height: 1, backgroundColor: colors.border },
   dividerText: { fontFamily: fonts.regular, color: colors.textMuted, fontSize: fontSize.sm },
+
   secondaryBtn: {
     backgroundColor: colors.card,
     borderRadius:    radius.md,

--- a/frontend/field-force-contractor/screens/OfflineLoginScreen.tsx
+++ b/frontend/field-force-contractor/screens/OfflineLoginScreen.tsx
@@ -1,25 +1,21 @@
-// OfflineLoginScreen.tsx  —  Troy
+// OfflineLoginScreen.tsx
+// PIN entry screen — reached after biometric login fails on BiometricScreen.
 //
-// This screen is the PIN entry fallback — reached when biometrics fail,
-// whether the device is online or offline.
-//
-// Previous architecture had this screen containing its own biometric step,
-// which caused the "goes back to biometrics" bug. That step has been removed.
-// BiometricScreen.tsx now handles ALL biometric attempts (online and offline).
-// This screen is purely: enter PIN → verify → go to Dashboard.
+// This screen is PIN ONLY. Biometrics are handled entirely by BiometricScreen
+// before the user ever gets here. There is no biometric step on this screen.
 //
 // Flow:
-//   Login → BiometricCheck → (fail) → here (PIN entry)
+//   BiometricScreen (fails) → "Use PIN instead" → OfflineLoginScreen (this screen)
 //
-// ─────────────────────────────────────────────────────────────────────────────
-// ⚙️  DEV MODE
+// "Reset PIN" opens an inline modal that collects the user's email and alerts
+// them that the vendor will send a new PIN after identity verification.
 //
-//  The dev PIN is set to "123456" for testing.
-//  In production, replace the PIN check in handlePinLogin() with:
-//    import * as SecureStore from 'expo-secure-store';
-//    const savedPin = await SecureStore.getItemAsync('offlinePin');
-//    if (pin !== savedPin) { setPinError('Incorrect PIN...'); return; }
-// ─────────────────────────────────────────────────────────────────────────────
+// ─────────────────────────────────────────────────────────────
+// DEV ONLY: The dev PIN is set to "123456" for testing.
+// In production replace the DEV_PIN check with:
+//   const savedPin = await SecureStore.getItemAsync('offlinePin');
+//   if (pin !== savedPin) { setPinError(...); return; }
+// ─────────────────────────────────────────────────────────────
 
 import { useState } from 'react';
 import {
@@ -28,250 +24,429 @@ import {
   TextInput,
   TouchableOpacity,
   StyleSheet,
+  StatusBar,
+  ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
+  Modal,
+  Alert,
 } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import { Ionicons }      from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
 import { RootStackParamList } from '../App';
-import { MainFrame } from '../components/MainFrame';
+import { MainFrame }          from '../components/MainFrame';
 import { colors, spacing, radius, fontSize, fonts } from '../constants/theme';
 
 type Nav = NativeStackNavigationProp<RootStackParamList, 'OfflineLogin'>;
 
-// DEV ONLY — replace with SecureStore lookup in production
-const DEV_PIN = '123456';
-
-// Amber — consistent with Login button and BiometricScreen throughout the app
-const AMBER = '#f59e0b';
+const DEV_PIN = '123456'; // DEV ONLY — remove before production
 
 export default function OfflineLoginScreen() {
   const navigation = useNavigation<Nav>();
 
-  const [pin,         setPin]         = useState('');
-  const [showPin,     setShowPin]     = useState(false); // eye icon toggle
-  const [pinError,    setPinError]    = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  // PIN state
+  const [pin,      setPin]      = useState('');
+  const [pinError, setPinError] = useState('');
 
-  // Only allow digits — strip anything else as the user types
+  // Reset PIN modal state
+  const [resetModalOpen,  setResetModalOpen]  = useState(false);
+  const [resetEmail,      setResetEmail]      = useState('');
+  const [resetSubmitting, setResetSubmitting] = useState(false);
+
+  const emailLooksValid = resetEmail.includes('@') && resetEmail.includes('.');
+
+  // ── PIN handlers ──────────────────────────────────────────
+
   const handlePinChange = (newValue: string) => {
-    const digitsOnly = newValue.replace(/\D/g, '').slice(0, 6);
-    setPin(digitsOnly);
-    setPinError(''); // clear error while typing
+    const trimmed = newValue.replace(/\D/g, '').slice(0, 6);
+    setPin(trimmed);
+    setPinError('');
   };
 
-  const handlePinLogin = async () => {
-    // Validate before checking
+  const handlePinLogin = () => {
     if (pin.length === 0) {
       setPinError('Please enter your 6-digit PIN.');
       return;
     }
     if (pin.length < 6) {
-      setPinError(`PIN is too short — ${pin.length}/6 digits entered.`);
+      setPinError(`PIN is too short — please enter all 6 digits (${pin.length}/6 entered).`);
       return;
     }
-
-    setIsSubmitting(true);
-
-    // Small delay so the spinner is visible
-    await new Promise(resolve => setTimeout(resolve, 600));
-
-    // ── DEV: compare against hardcoded PIN ────────────────────────────────
-    // In production replace with SecureStore lookup — see note at top of file
+    // DEV ONLY — replace with SecureStore check in production
     if (pin !== DEV_PIN) {
       setPinError('Incorrect PIN. Please try again.');
-      setIsSubmitting(false);
       return;
     }
-    // ─────────────────────────────────────────────────────────────────────
-
-    navigation.replace('Inspection');
+    navigation.replace('Home');
   };
 
+  // ── Reset PIN modal handlers ──────────────────────────────
+
+  const openResetModal = () => {
+    setResetEmail('');
+    setResetSubmitting(false);
+    setResetModalOpen(true);
+  };
+
+  const handleResetSubmit = () => {
+    if (!emailLooksValid) return;
+    setResetSubmitting(true);
+
+    // TODO: In production, send this request to your backend API or save
+    // it locally in AsyncStorage to be sent once the device is back online.
+    // The vendor then verifies identity and contacts the user with a new PIN.
+    setTimeout(() => {
+      setResetSubmitting(false);
+      setResetModalOpen(false);
+      setResetEmail('');
+      Alert.alert(
+        'Request Sent',
+        'Your PIN reset request has been sent to the Vendor.\n\nThey will reach out to you with a new PIN after verification.',
+        [{ text: 'OK' }],
+      );
+    }, 800);
+  };
+
+  // ── Render ────────────────────────────────────────────────
+
   return (
-    <MainFrame header="default" headerMenu={['none']} footerMenu={['none']}>
-        <KeyboardAvoidingView
-          style={styles.kav}
-          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    <MainFrame header="default" headerMenu={['Menu2', ['Offline PIN']]} footerMenu={['none', []]}>
+      <StatusBar barStyle="light-content" backgroundColor="transparent" translucent />
+
+      <KeyboardAvoidingView
+        style={styles.kav}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
         >
-          <ScrollView
-            contentContainerStyle={styles.scroll}
-            keyboardShouldPersistTaps="handled"
-            showsVerticalScrollIndicator={false}
-          >
+          {/* Keypad illustration */}
+          <View style={styles.keypadIllustration}>
+            <Ionicons name="keypad" size={64} color={colors.primary} />
+          </View>
 
-            {/* Keypad icon — visual indicator for what this screen is */}
-            <View style={styles.iconWrap}>
-              <View style={styles.iconCircle}>
-                <Ionicons name="keypad" size={52} color={AMBER} />
+          {/* Explanation */}
+          <View style={styles.infoBox}>
+            <Ionicons name="information-circle-outline" size={18} color={colors.primary} />
+            <Text style={styles.infoText}>
+              Biometric login failed. Enter your 6-digit offline PIN to continue.
+            </Text>
+          </View>
+
+          <View style={styles.pinForm}>
+
+            {/* PIN input */}
+            <View style={styles.fieldGroup}>
+              <View style={styles.labelRow}>
+                <Text style={styles.label}>Offline PIN</Text>
+                <Text style={styles.pinCounter}>{pin.length}/6</Text>
               </View>
-            </View>
 
-            {/* Explanation — tells the user why they're seeing this screen */}
-            <View style={styles.infoBlock}>
-              <Text style={styles.infoTitle}>PIN VERIFICATION</Text>
-              <View style={styles.infoLine} />
-              <Text style={styles.infoSub}>
-                Biometric login failed. Enter your 6-digit PIN to continue.
-              </Text>
-              {/* DEV ONLY reminder — remove before production */}
-              <Text style={styles.devNote}>Dev PIN: {DEV_PIN}</Text>
-            </View>
+              <TextInput
+                style={[styles.pinInput, pinError !== '' && styles.pinInputError]}
+                value={pin}
+                onChangeText={handlePinChange}
+                placeholder="Enter 6-digit PIN"
+                placeholderTextColor={colors.textMuted}
+                keyboardType="numeric"
+                secureTextEntry
+                maxLength={6}
+                autoFocus
+              />
 
-            <View style={styles.form}>
-
-              {/* PIN input */}
-              <View style={styles.fieldGroup}>
-                <Text style={styles.label}>PIN Code</Text>
-                <View style={styles.inputRow}>
-                  <TextInput
-                    style={[
-                      styles.input,
-                      styles.pinInput,
-                      pinError ? styles.inputError : null,
-                    ]}
-                    value={pin}
-                    onChangeText={handlePinChange}
-                    placeholder="• • • • • •"
-                    placeholderTextColor={colors.textMuted}
-                    secureTextEntry={!showPin}
-                    keyboardType="numeric"
-                    maxLength={6}
-                    autoFocus
-                  />
-                  {/* Eye icon — toggles PIN visibility */}
-                  <TouchableOpacity
-                    style={styles.eyeBtn}
-                    onPress={() => setShowPin(!showPin)}
-                  >
-                    <Ionicons
-                      name={showPin ? 'eye-off-outline' : 'eye-outline'}
-                      size={20}
-                      color={colors.textMuted}
-                    />
-                  </TouchableOpacity>
+              {pinError !== '' && (
+                <View style={styles.errorRow}>
+                  <Ionicons name="alert-circle-outline" size={14} color={colors.error} />
+                  <Text style={styles.errorText}>{pinError}</Text>
                 </View>
-
-                {/* Error message — only shows when pinError has content */}
-                {pinError !== '' && (
-                  <View style={styles.fieldErrorRow}>
-                    <Ionicons name="alert-circle-outline" size={14} color={colors.error} />
-                    <Text style={styles.fieldErrorText}>{pinError}</Text>
-                  </View>
-                )}
-              </View>
-
-              {/* PIN length indicator dots — shows how many digits entered */}
-              <View style={styles.dotsRow}>
-                {[1, 2, 3, 4, 5, 6].map(i => (
-                  <View
-                    key={i}
-                    style={[styles.dot, pin.length >= i && styles.dotFilled]}
-                  />
-                ))}
-              </View>
-
-              {/* Verify PIN button — amber to match the rest of the app */}
-              <TouchableOpacity
-                style={[
-                  styles.submitBtn,
-                  (pin.length < 6 || isSubmitting) && styles.submitBtnDisabled,
-                ]}
-                onPress={handlePinLogin}
-                activeOpacity={0.85}
-                disabled={pin.length < 6 || isSubmitting}
-              >
-                {isSubmitting ? (
-                  <View style={styles.submitRow}>
-                    <Text style={styles.submitBtnText}>Verifying…</Text>
-                  </View>
-                ) : (
-                  <Text style={styles.submitBtnText}>Verify PIN</Text>
-                )}
-              </TouchableOpacity>
-
-              {/* Back to login — lets the user start over if needed */}
-              <TouchableOpacity
-                style={styles.backBtn}
-                onPress={() => navigation.replace('Login')}
-                activeOpacity={0.8}
-              >
-                <Text style={styles.backBtnText}>Back to Login</Text>
-              </TouchableOpacity>
-
+              )}
             </View>
 
-          </ScrollView>
+            {/* Login button */}
+            <TouchableOpacity
+              style={[styles.loginBtn, pin.length < 6 && styles.btnDisabled]}
+              onPress={handlePinLogin}
+              activeOpacity={0.85}
+            >
+              <Text style={styles.loginBtnText}>Login</Text>
+            </TouchableOpacity>
+
+            {/* Reset PIN button */}
+            <TouchableOpacity
+              style={styles.resetPinBtn}
+              onPress={openResetModal}
+              activeOpacity={0.8}
+            >
+              <Ionicons name="refresh-circle-outline" size={18} color={colors.primary} />
+              <Text style={styles.resetPinBtnText}>Reset PIN</Text>
+            </TouchableOpacity>
+
+            {/* DEV reminder */}
+            <View style={styles.devBanner}>
+              <Ionicons name="construct-outline" size={14} color={colors.warning} />
+              <Text style={styles.devBannerText}>
+                DEV MODE — Test PIN: {DEV_PIN}
+              </Text>
+            </View>
+
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+
+      {/* ── Reset PIN Modal ──────────────────────────────────────────────── */}
+      <Modal
+        visible={resetModalOpen}
+        animationType="slide"
+        transparent={true}
+        onRequestClose={() => setResetModalOpen(false)}
+      >
+        <TouchableOpacity
+          style={modalStyles.backdrop}
+          activeOpacity={1}
+          onPress={() => setResetModalOpen(false)}
+        />
+
+        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+          <View style={modalStyles.sheet}>
+
+            <View style={modalStyles.handle} />
+
+            <View style={modalStyles.sheetHeader}>
+              <View style={modalStyles.sheetTitleRow}>
+                <Ionicons name="refresh-circle-outline" size={22} color={colors.primary} />
+                <Text style={modalStyles.sheetTitle}>Reset PIN</Text>
+              </View>
+              <TouchableOpacity onPress={() => setResetModalOpen(false)} activeOpacity={0.7}>
+                <Ionicons name="close" size={22} color={colors.textMuted} />
+              </TouchableOpacity>
+            </View>
+
+            <View style={modalStyles.infoBox}>
+              <Ionicons name="information-circle-outline" size={18} color={colors.primary} />
+              <Text style={modalStyles.infoText}>
+                Offline PINs are managed by your Vendor. Enter your email address below and your Vendor will send you a new PIN after verifying your identity.
+              </Text>
+            </View>
+
+            <View style={modalStyles.fieldGroup}>
+              <Text style={modalStyles.label}>Email Address</Text>
+              <TextInput
+                style={[
+                  modalStyles.input,
+                  !emailLooksValid && resetEmail.length > 0 && modalStyles.inputError,
+                ]}
+                value={resetEmail}
+                onChangeText={setResetEmail}
+                placeholder="Enter your email address"
+                placeholderTextColor={colors.textMuted}
+                autoCapitalize="none"
+                keyboardType="email-address"
+                autoFocus
+              />
+              {resetEmail.length > 0 && !emailLooksValid && (
+                <View style={modalStyles.errorRow}>
+                  <Ionicons name="alert-circle-outline" size={14} color={colors.error} />
+                  <Text style={modalStyles.errorText}>Please enter a valid email address.</Text>
+                </View>
+              )}
+            </View>
+
+            <TouchableOpacity
+              style={[
+                modalStyles.submitBtn,
+                (!emailLooksValid || resetSubmitting) && modalStyles.submitBtnDisabled,
+              ]}
+              onPress={handleResetSubmit}
+              activeOpacity={0.85}
+              disabled={!emailLooksValid || resetSubmitting}
+            >
+              {resetSubmitting ? (
+                <ActivityIndicator color={colors.textWhite} />
+              ) : (
+                <>
+                  <Ionicons name="send-outline" size={16} color={colors.textWhite} />
+                  <Text style={modalStyles.submitBtnText}>Send Reset Request</Text>
+                </>
+              )}
+            </TouchableOpacity>
+
+          </View>
         </KeyboardAvoidingView>
+      </Modal>
+
     </MainFrame>
   );
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Styles
-// ─────────────────────────────────────────────────────────────────────────────
+// ── Screen styles ─────────────────────────────────────────────────────────────
 const styles = StyleSheet.create({
-  kav:             { flex: 1, width: '100%' },
+  kav:        { width: '100%' },
+
   scroll: {
     flexGrow:          1,
     alignItems:        'center',
     paddingHorizontal: spacing.lg,
+    paddingTop:        spacing.xl,
     paddingBottom:     spacing.xl,
   },
 
-  // ── Icon ─────────────────────────────────────────────────────────────────
-  iconWrap: { marginTop: spacing.xl, marginBottom: spacing.md },
-  iconCircle: {
-    width:           100,
-    height:          100,
-    borderRadius:    50,
-    backgroundColor: 'rgba(245, 158, 11, 0.1)',
-    borderWidth:     2,
-    borderColor:     AMBER,
+  keypadIllustration: {
+    width:           120,
+    height:          120,
+    borderRadius:    60,
+    backgroundColor: '#1e2d45',
     alignItems:      'center',
     justifyContent:  'center',
+    marginBottom:    spacing.lg,
   },
 
-  // ── Info block ────────────────────────────────────────────────────────────
-  infoBlock: { alignItems: 'center', marginBottom: spacing.lg },
-  infoTitle: {
-    fontFamily:    fonts.bold,
-    fontSize:      fontSize.lg,
-    color:         colors.textWhite,
-    letterSpacing: 1.5,
+  infoBox: {
+    flexDirection:   'row',
+    alignItems:      'flex-start',
+    gap:             spacing.sm,
+    backgroundColor: colors.primaryFaint,
+    borderWidth:     1,
+    borderColor:     colors.primary,
+    borderRadius:    radius.md,
+    padding:         spacing.md,
+    marginBottom:    spacing.lg,
+    width:           '100%',
+    maxWidth:        380,
   },
-  infoLine: {
-    width:           '70%',
-    height:          2,
-    backgroundColor: colors.textWhite,
-    marginVertical:  6,
-  },
-  infoSub: {
+  infoText: {
+    flex:       1,
     fontFamily: fonts.regular,
     fontSize:   fontSize.sm,
     color:      colors.textLight,
-    textAlign:  'center',
     lineHeight: 20,
-    marginBottom: 8,
   },
-  // DEV ONLY — remove before production
-  devNote: {
+
+  pinForm:    { width: '100%', maxWidth: 380, gap: spacing.md },
+  fieldGroup: { gap: 6 },
+  labelRow: {
+    flexDirection:  'row',
+    justifyContent: 'space-between',
+    alignItems:     'center',
+  },
+  label:      { fontFamily: fonts.regular, fontSize: fontSize.sm, color: colors.textLight },
+  pinCounter: { fontFamily: fonts.regular, fontSize: fontSize.sm, color: colors.textMuted },
+
+  pinInput: {
+    width:             '100%',
+    backgroundColor:   colors.card,
+    borderRadius:      radius.md,
+    borderWidth:       1,
+    borderColor:       colors.border,
+    paddingHorizontal: spacing.md,
+    paddingVertical:   14,
+    fontFamily:        fonts.bold,
+    color:             colors.textWhite,
+    fontSize:          fontSize.xl,
+    textAlign:         'center',
+    letterSpacing:     8,
+  },
+  pinInputError: { borderColor: colors.error },
+
+  errorRow:  { flexDirection: 'row', alignItems: 'center', gap: 5, marginTop: 2 },
+  errorText: { fontFamily: fonts.regular, fontSize: fontSize.xs, color: colors.error, flex: 1 },
+
+  loginBtn: {
+    backgroundColor: colors.primary,
+    borderRadius:    radius.md,
+    paddingVertical: 15,
+    alignItems:      'center',
+    marginTop:       spacing.sm,
+  },
+  btnDisabled:  { backgroundColor: colors.cardAlt },
+  loginBtnText: {
     fontFamily:    fonts.bold,
-    fontSize:      fontSize.xs,
-    color:         colors.warning,
+    color:         colors.textWhite,
+    fontSize:      fontSize.base,
     letterSpacing: 0.5,
   },
 
-  // ── Form ──────────────────────────────────────────────────────────────────
-  form:       { width: '100%', maxWidth: 380, gap: spacing.md },
+  resetPinBtn: {
+    flexDirection:   'row',
+    alignItems:      'center',
+    justifyContent:  'center',
+    gap:             8,
+    paddingVertical: 13,
+    borderRadius:    radius.md,
+    borderWidth:     1,
+    borderColor:     colors.primary,
+    backgroundColor: colors.primaryFaint,
+  },
+  resetPinBtnText: { fontFamily: fonts.bold, fontSize: fontSize.base, color: colors.primary },
+
+  devBanner: {
+    flexDirection:     'row',
+    alignItems:        'center',
+    gap:               6,
+    backgroundColor:   'rgba(245,158,11,0.10)',
+    borderWidth:       1,
+    borderColor:       colors.warning,
+    borderRadius:      radius.md,
+    paddingVertical:   8,
+    paddingHorizontal: spacing.md,
+  },
+  devBannerText: { fontFamily: fonts.regular, fontSize: fontSize.xs, color: colors.warning, flex: 1 },
+});
+
+// ── Reset PIN modal styles ─────────────────────────────────────────────────────
+const modalStyles = StyleSheet.create({
+  backdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)' },
+
+  sheet: {
+    backgroundColor:      colors.card,
+    borderTopLeftRadius:  24,
+    borderTopRightRadius: 24,
+    paddingHorizontal:    spacing.lg,
+    paddingBottom:        spacing.xl,
+    paddingTop:           spacing.sm,
+    gap:                  spacing.md,
+  },
+
+  handle: {
+    width:           40,
+    height:          4,
+    borderRadius:    2,
+    backgroundColor: colors.border,
+    alignSelf:       'center',
+    marginBottom:    spacing.sm,
+  },
+
+  sheetHeader:   { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  sheetTitleRow: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
+  sheetTitle:    { fontFamily: fonts.bold, fontSize: fontSize.lg, color: colors.textWhite },
+
+  infoBox: {
+    flexDirection:   'row',
+    alignItems:      'flex-start',
+    gap:             spacing.sm,
+    backgroundColor: colors.primaryFaint,
+    borderWidth:     1,
+    borderColor:     colors.primary,
+    borderRadius:    radius.md,
+    padding:         spacing.md,
+  },
+  infoText: {
+    flex:       1,
+    fontFamily: fonts.regular,
+    fontSize:   fontSize.sm,
+    color:      colors.textLight,
+    lineHeight: 20,
+  },
+
   fieldGroup: { gap: 6 },
   label:      { fontFamily: fonts.regular, fontSize: fontSize.sm, color: colors.textLight },
-
   input: {
     width:             '100%',
-    backgroundColor:   colors.card,
+    backgroundColor:   colors.background,
     borderRadius:      radius.md,
     borderWidth:       1,
     borderColor:       colors.border,
@@ -281,78 +456,24 @@ const styles = StyleSheet.create({
     color:             colors.textWhite,
     fontSize:          fontSize.base,
   },
-  // PIN input is centered with wide letter spacing to look like • • • • • •
-  pinInput: {
-    textAlign:     'center',
-    letterSpacing: 8,
-    paddingRight:  48, // room for eye icon
-  },
   inputError: { borderColor: colors.error },
-  inputRow:   { flexDirection: 'row', alignItems: 'center' },
-  eyeBtn:     { position: 'absolute', right: 14, top: 14 },
+  errorRow:   { flexDirection: 'row', alignItems: 'center', gap: 5, marginTop: 2 },
+  errorText:  { fontFamily: fonts.regular, fontSize: fontSize.xs, color: colors.error, flex: 1 },
 
-  fieldErrorRow: {
-    flexDirection: 'row',
-    alignItems:    'center',
-    gap:           5,
-    marginTop:     2,
-  },
-  fieldErrorText: {
-    fontFamily: fonts.regular,
-    fontSize:   fontSize.xs,
-    color:      colors.error,
-    flex:       1,
-  },
-
-  // ── PIN dot indicators ────────────────────────────────────────────────────
-  dotsRow: {
-    flexDirection:  'row',
-    justifyContent: 'center',
-    gap:            10,
-    marginTop:      spacing.xs,
-  },
-  dot: {
-    width:           12,
-    height:          12,
-    borderRadius:    6,
-    backgroundColor: colors.border,
-    borderWidth:     1,
-    borderColor:     colors.textMuted,
-  },
-  dotFilled: {
-    backgroundColor: AMBER,
-    borderColor:     AMBER,
-  },
-
-  // ── Submit button — amber fill matches Login button ───────────────────────
   submitBtn: {
-    backgroundColor: AMBER,
+    flexDirection:   'row',
+    alignItems:      'center',
+    justifyContent:  'center',
+    gap:             spacing.sm,
+    backgroundColor: colors.primary,
     borderRadius:    radius.md,
     paddingVertical: 15,
-    alignItems:      'center',
-    marginTop:       spacing.sm,
   },
   submitBtnDisabled: { backgroundColor: colors.cardAlt },
-  submitRow:         { flexDirection: 'row', alignItems: 'center', gap: 8 },
   submitBtnText: {
     fontFamily:    fonts.bold,
     color:         colors.textWhite,
     fontSize:      fontSize.base,
     letterSpacing: 0.5,
-  },
-
-  // ── Back to login ─────────────────────────────────────────────────────────
-  backBtn: {
-    backgroundColor: colors.card,
-    borderRadius:    radius.md,
-    borderWidth:     1,
-    borderColor:     colors.border,
-    paddingVertical: 14,
-    alignItems:      'center',
-  },
-  backBtnText: {
-    fontFamily: fonts.regular,
-    color:      colors.textLight,
-    fontSize:   fontSize.base,
   },
 });

--- a/frontend/field-force-contractor/screens/PasswordResetScreen.tsx
+++ b/frontend/field-force-contractor/screens/PasswordResetScreen.tsx
@@ -1,30 +1,44 @@
-// PasswordResetScreen.tsx
+// PasswordResetScreen.tsx  —  Troy
 // This screen has two steps:
 //   Step 1 — The user enters their email + new password
 //   Step 2 — They verify their identity with Face ID or fingerprint
 //            before the password is actually saved
 //
-// There's no bottom navigation bar here because the user
-// shouldn't be navigating elsewhere mid-reset.
+// Uses MainFrame header="default" with no footer nav since the user
+// should not be navigating elsewhere mid-reset.
+//
+// Menu2 provides the back arrow and title via headerMenu prop.
+// onBack steps back to the form on step 2 rather than leaving the
+// screen — Menu2's back arrow only calls navigation.goBack().
+//
+// ── BIOMETRIC DEFAULT ─────────────────────────────────────────────────────────
+// The biometric method is loaded from AsyncStorage on mount using the same
+// key that ProfileScreen writes to, so the user's saved preference is always
+// respected when step 2 opens.
+// ──────────────────────────────────────────────────────────────────────────────
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   View,
   Text,
   TextInput,
   TouchableOpacity,
   StyleSheet,
+  StatusBar,
   Alert,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
   ActivityIndicator,
 } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Ionicons }      from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { RootStackParamList } from '../App';
-import { MainFrame } from '../components/MainFrame';
+
+import { RootStackParamList }     from '../App';
+import { MainFrame }              from '../components/MainFrame';
+import { SETTINGS_BIOMETRIC_KEY } from './ProfileScreen';
 import { colors, spacing, radius, fontSize, fonts } from '../constants/theme';
 
 type Nav = NativeStackNavigationProp<RootStackParamList, 'PasswordReset'>;
@@ -39,65 +53,64 @@ export default function PasswordResetScreen() {
   const [showNew,         setShowNew]         = useState(false);
   const [showConfirm,     setShowConfirm]     = useState(false);
 
-  // Which step we're on — 'form' or 'biometric'
+  // Which step we're on
   const [currentStep, setCurrentStep] = useState('form');
 
   // Biometric state for step 2
   const [biometricMethod, setBiometricMethod] = useState('fingerprint');
   const [scanState,       setScanState]       = useState('idle');
 
-  // The Continue button should only be enabled when all fields are filled
-  // and the passwords match each other
+  // Load the user's saved biometric preference from AsyncStorage on mount
+  // so step 2 opens with the correct method pre-selected
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const saved = await AsyncStorage.getItem(SETTINGS_BIOMETRIC_KEY);
+        if (saved === 'face' || saved === 'fingerprint') {
+          setBiometricMethod(saved);
+        }
+      } catch {
+        // Fall back to fingerprint default
+      }
+    };
+    load();
+  }, []);
+
   const formIsReady =
     email.length > 0 &&
     newPassword.length >= 6 &&
     newPassword === confirmPassword;
 
-  // Runs when the user taps "Continue to Verification"
   const handleContinue = () => {
     if (!formIsReady) return;
     setCurrentStep('biometric');
-  }
+  };
 
-  // Switches biometric method and resets the scan state
   const switchBiometricMethod = (method: string) => {
     setBiometricMethod(method);
     setScanState('idle');
-  }
+  };
 
-  // Runs when the user taps the biometric scan button
   const handleBiometricScan = () => {
     if (scanState === 'scanning') return;
-
     setScanState('scanning');
 
-    // TODO: Replace with real biometric call using expo-local-authentication:
-    //   const result = await LocalAuthentication.authenticateAsync({ promptMessage: 'Verify identity' });
-    //   if (result.success) { save the password, then navigate to Login }
-    //   else { setScanState('failed'); }
+    // TODO: Replace with real expo-local-authentication call
     setTimeout(() => {
-      const success = Math.random() > 0.3; // 70% success rate while testing
-
+      const success = Math.random() > 0.3;
       if (success) {
-        // TODO: Call your password-reset API here with email + newPassword before navigating
         Alert.alert(
           'Password Reset',
           'Your password has been updated successfully.',
-          [
-            {
-              text: 'OK',
-              onPress: () => navigation.navigate('Login'),
-            },
-          ],
+          [{ text: 'OK', onPress: () => navigation.navigate('Login') }],
         );
       } else {
         setScanState('failed');
       }
     }, 1500);
-  }
+  };
 
-  // When the back arrow is pressed on step 2, go back to the form
-  // instead of leaving the screen entirely
+  // On step 2, back arrow returns to the form rather than leaving the screen
   const handleBackPress = () => {
     if (currentStep === 'biometric') {
       setCurrentStep('form');
@@ -105,15 +118,20 @@ export default function PasswordResetScreen() {
     } else {
       navigation.goBack();
     }
-  }
+  };
 
   return (
-    <MainFrame header="default" headerMenu={['none']} footerMenu={['none']}>
+    <MainFrame
+      header="default"
+      headerMenu={['Menu2', ['Reset Password']]}
+      footerMenu={['none', []]}
+    >
+      <StatusBar barStyle="light-content" backgroundColor="transparent" translucent />
 
-      {/* ── STEP 1: The password reset form ─────────────────── */}
+      {/* ── STEP 1: Password reset form ───────────────────────── */}
       {currentStep === 'form' && (
         <KeyboardAvoidingView
-          style={styles.flex}
+          style={styles.kav}
           behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         >
           <ScrollView
@@ -121,7 +139,7 @@ export default function PasswordResetScreen() {
             keyboardShouldPersistTaps="handled"
             showsVerticalScrollIndicator={false}
           >
-            {/* Lock icon with a refresh badge to represent "reset" */}
+            {/* Lock + refresh badge illustration */}
             <View style={styles.illustrationWrap}>
               <View style={styles.illustrationCircle}>
                 <Ionicons name="lock-closed" size={48} color={colors.textWhite} />
@@ -133,21 +151,22 @@ export default function PasswordResetScreen() {
 
             <View style={styles.form}>
 
-              {/* Email field */}
+              {/* Email — label above, no placeholder text inside the box */}
               <View style={styles.fieldGroup}>
                 <Text style={styles.label}>Email Address</Text>
                 <TextInput
                   style={styles.input}
                   value={email}
                   onChangeText={setEmail}
-                  placeholder="Username"
+                  placeholder=""
                   placeholderTextColor={colors.textMuted}
                   autoCapitalize="none"
                   keyboardType="email-address"
+                  accessibilityLabel="Email Address"
                 />
               </View>
 
-              {/* New password field */}
+              {/* New Password — label above, no placeholder text */}
               <View style={styles.fieldGroup}>
                 <Text style={styles.label}>New Password</Text>
                 <View>
@@ -155,10 +174,11 @@ export default function PasswordResetScreen() {
                     style={[styles.input, styles.inputPadRight]}
                     value={newPassword}
                     onChangeText={setNewPassword}
-                    placeholder="Password"
+                    placeholder=""
                     placeholderTextColor={colors.textMuted}
                     secureTextEntry={!showNew}
                     autoCapitalize="none"
+                    accessibilityLabel="New Password"
                   />
                   <TouchableOpacity style={styles.eyeBtn} onPress={() => setShowNew(!showNew)}>
                     <Ionicons
@@ -170,7 +190,7 @@ export default function PasswordResetScreen() {
                 </View>
               </View>
 
-              {/* Confirm password field */}
+              {/* Confirm Password — label above, no placeholder text */}
               <View style={styles.fieldGroup}>
                 <Text style={styles.label}>Confirm Password</Text>
                 <View>
@@ -178,10 +198,11 @@ export default function PasswordResetScreen() {
                     style={[styles.input, styles.inputPadRight]}
                     value={confirmPassword}
                     onChangeText={setConfirmPassword}
-                    placeholder="Confirm Password"
+                    placeholder=""
                     placeholderTextColor={colors.textMuted}
                     secureTextEntry={!showConfirm}
                     autoCapitalize="none"
+                    accessibilityLabel="Confirm Password"
                   />
                   <TouchableOpacity style={styles.eyeBtn} onPress={() => setShowConfirm(!showConfirm)}>
                     <Ionicons
@@ -191,13 +212,11 @@ export default function PasswordResetScreen() {
                     />
                   </TouchableOpacity>
                 </View>
-                {/* Only show the mismatch message if they've started typing in confirm */}
                 {confirmPassword.length > 0 && newPassword !== confirmPassword && (
                   <Text style={styles.mismatchText}>Passwords do not match</Text>
                 )}
               </View>
 
-              {/* Continue button — grayed out until form is valid */}
               <TouchableOpacity
                 style={[styles.primaryBtn, !formIsReady && styles.btnDisabled]}
                 onPress={handleContinue}
@@ -212,7 +231,8 @@ export default function PasswordResetScreen() {
         </KeyboardAvoidingView>
       )}
 
-      {/* ── STEP 2: Biometric verification ──────────────────── */}
+      {/* ── STEP 2: Biometric verification ──────────────────────
+          Opens with the method the user saved in Profile settings */}
       {currentStep === 'biometric' && (
         <View style={styles.bioContainer}>
 
@@ -221,7 +241,7 @@ export default function PasswordResetScreen() {
             Confirm who you are before saving your new password.
           </Text>
 
-          {/* Face ID / Fingerprint toggle */}
+          {/* Method toggle — pre-selected from saved AsyncStorage preference */}
           <View style={styles.methodRow}>
             <TouchableOpacity
               style={[styles.methodBtn, biometricMethod === 'face' && styles.methodBtnActive]}
@@ -254,7 +274,7 @@ export default function PasswordResetScreen() {
             </TouchableOpacity>
           </View>
 
-          {/* The big scan button */}
+          {/* Scan button */}
           <TouchableOpacity
             style={[
               styles.scanBtn,
@@ -276,7 +296,6 @@ export default function PasswordResetScreen() {
             )}
           </TouchableOpacity>
 
-          {/* State-based status messages */}
           {scanState === 'idle' && (
             <Text style={styles.hintText}>
               {biometricMethod === 'face' ? 'Tap to scan your face' : 'Tap to scan fingerprint'}
@@ -285,28 +304,15 @@ export default function PasswordResetScreen() {
           {scanState === 'scanning' && (
             <Text style={styles.hintText}>Scanning…</Text>
           )}
+
+          {/* Failed state — retry only, no PIN option (this is a password reset, not login) */}
           {scanState === 'failed' && (
             <View style={styles.failedSection}>
               <Text style={styles.errorText}>Scan failed — please try again.</Text>
-              <TouchableOpacity
-                style={styles.retryBtn}
-                onPress={() => setScanState('idle')}
-              >
+              <TouchableOpacity style={styles.retryBtn} onPress={() => setScanState('idle')}>
                 <Text style={styles.retryBtnText}>Retry</Text>
               </TouchableOpacity>
             </View>
-          )}
-
-          {/* Quick switch between Face ID and fingerprint */}
-          {scanState === 'idle' && (
-            <TouchableOpacity
-              onPress={() => switchBiometricMethod(biometricMethod === 'face' ? 'fingerprint' : 'face')}
-              activeOpacity={0.7}
-            >
-              <Text style={styles.switchLinkText}>
-                Use {biometricMethod === 'face' ? 'fingerprint' : 'Face ID'} instead
-              </Text>
-            </TouchableOpacity>
           )}
 
         </View>
@@ -316,7 +322,7 @@ export default function PasswordResetScreen() {
 }
 
 const styles = StyleSheet.create({
-  flex:       { flex: 1 },
+  kav:        { flex: 1, width: '100%' },
   scroll: {
     flexGrow:          1,
     alignItems:        'center',
@@ -324,7 +330,6 @@ const styles = StyleSheet.create({
     paddingBottom:     spacing.xl,
   },
 
-  // Illustration
   illustrationWrap: {
     alignItems:     'center',
     justifyContent: 'center',
@@ -355,7 +360,6 @@ const styles = StyleSheet.create({
     justifyContent:  'center',
   },
 
-  // Form (step 1)
   form:       { width: '100%', maxWidth: 380, gap: spacing.md },
   fieldGroup: { gap: 6 },
   label:      { fontFamily: fonts.regular, fontSize: fontSize.sm, color: colors.textLight },
@@ -394,7 +398,6 @@ const styles = StyleSheet.create({
     letterSpacing: 0.5,
   },
 
-  // Biometric (step 2)
   bioContainer: {
     flex:              1,
     alignItems:        'center',
@@ -466,10 +469,4 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.xl,
   },
   retryBtnText:   { fontFamily: fonts.bold, color: colors.textWhite, fontSize: fontSize.base },
-  switchLinkText: {
-    fontFamily:         fonts.regular,
-    fontSize:           fontSize.sm,
-    color:              colors.textMuted,
-    textDecorationLine: 'underline',
-  },
 });

--- a/frontend/field-force-contractor/screens/ProfileScreen.tsx
+++ b/frontend/field-force-contractor/screens/ProfileScreen.tsx
@@ -1,32 +1,46 @@
-// ProfileScreen.tsx
+// ProfileScreen.tsx  —  Troy
 // Shows the logged-in contractor's profile information.
-// Reached by tapping the avatar icon in the top-right of any screen.
 //
-// Sections:
-//   1. Avatar + name + contractor ID + vendor
-//   2. Contact info (email, phone, address)
-//   3. Menu rows (License, Settings, Logout)
+// Menu rows:
+//   License       — contractor license details
+//   Task History  — full history of completed and incomplete tasks
+//   Settings      — biometric preference + appearance toggle
+//   Logout        — clears session and returns to Login
+//
+// Settings modal persists two preferences via AsyncStorage:
+//   Default biometric method  — read by BiometricScreen on next login
+//   Appearance (dark/light)   — applied app-wide via ThemeContext
 
+import { useState, useEffect } from 'react';
 import {
   View,
   Text,
   TouchableOpacity,
   StyleSheet,
+  StatusBar,
+  Modal,
+  Switch,
+  Alert,
 } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Ionicons }  from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
 import { RootStackParamList } from '../App';
 import { MainFrame } from '../components/MainFrame';
-import { colors, spacing, radius, fontSize, fonts } from '../constants/theme';
-import { useAuth } from '../contexts/AuthContext';
+
+import { useTheme }           from '../contexts/ThemeContext';
+import { spacing, radius, fontSize, fonts } from '../constants/theme';
+import { useAuth }            from '../contexts/AuthContext';
 
 type Nav = NativeStackNavigationProp<RootStackParamList, 'Profile'>;
 
-// ---------------------------------------------------------------
-// Placeholder contractor data — replace with real data from auth
-// context or API once the backend is ready
-// ---------------------------------------------------------------
+export const SETTINGS_BIOMETRIC_KEY  = 'settings:defaultBiometric';
+export const SETTINGS_LIGHT_MODE_KEY = 'settings:lightMode';
+
+// ── Placeholder contractor data ───────────────────────────────
+// Replace with real data from AuthContext or the backend API
 const CONTRACTOR = {
   name:         'John Doe',
   contractorId: '5555555',
@@ -36,87 +50,100 @@ const CONTRACTOR = {
   address:      '2000 Alee Lane, Lancaster, SC 28550',
 };
 
-// ---------------------------------------------------------------
-// InfoRow — reusable contact-detail row
-// ---------------------------------------------------------------
-const InfoRow = (props: { icon: any; label: string; value: string }) => (
-  <View style={infoStyles.row}>
-    <Ionicons name={props.icon} size={18} color={colors.textMuted} />
+// ── InfoRow ───────────────────────────────────────────────────
+const InfoRow = ({ icon, label, value, colors }: {
+  icon: any; label: string; value: string; colors: any;
+}) => (
+  <View style={[infoStyles.row, { backgroundColor: colors.card, borderColor: colors.border }]}>
+    <Ionicons name={icon} size={18} color={colors.textMuted} />
     <View style={infoStyles.textWrap}>
-      <Text style={infoStyles.label}>{props.label}</Text>
-      <Text style={infoStyles.value}>{props.value}</Text>
+      <Text style={[infoStyles.label, { color: colors.textMuted }]}>{label}</Text>
+      <Text style={[infoStyles.value, { color: colors.textWhite }]}>{value}</Text>
     </View>
   </View>
 );
 
 const infoStyles = StyleSheet.create({
-  row: {
-    flexDirection:     'row',
-    alignItems:        'center',
-    backgroundColor:   'rgba(26, 43, 66, 0.85)', // cards use a translucent navy so the bg image shows through
-    borderRadius:      radius.md,
-    borderWidth:       1,
-    borderColor:       colors.border,
-    paddingVertical:   12,
-    paddingHorizontal: spacing.md,
-    gap:               spacing.md,
-  },
+  row:      { flexDirection: 'row', alignItems: 'center', borderRadius: radius.md, borderWidth: 1, paddingVertical: 12, paddingHorizontal: spacing.md, gap: spacing.md },
   textWrap: { flex: 1 },
-  label:    { fontFamily: fonts.regular, fontSize: fontSize.xs, color: colors.textMuted, marginBottom: 2 },
-  value:    { fontFamily: fonts.regular, fontSize: fontSize.sm, color: colors.textWhite },
+  label:    { fontFamily: fonts.regular, fontSize: fontSize.xs, marginBottom: 2 },
+  value:    { fontFamily: fonts.regular, fontSize: fontSize.sm },
 });
 
-// ---------------------------------------------------------------
-// MenuRow — tappable row with icon, label, and optional chevron
-// ---------------------------------------------------------------
-type MenuRowProps = {
-  icon:     any;
-  label:    string;
-  onPress?: () => void;
-  danger?:  boolean;
-};
-
-const MenuRow = (props: MenuRowProps) => (
-  <TouchableOpacity style={menuStyles.row} onPress={props.onPress} activeOpacity={0.75}>
+// ── MenuRow ───────────────────────────────────────────────────
+const MenuRow = ({ icon, label, onPress, danger, colors }: {
+  icon: any; label: string; onPress?: () => void; danger?: boolean; colors: any;
+}) => (
+  <TouchableOpacity
+    style={[menuStyles.row, { backgroundColor: colors.card, borderColor: colors.border }]}
+    onPress={onPress}
+    activeOpacity={0.75}
+  >
     <View style={menuStyles.left}>
-      <Ionicons
-        name={props.icon}
-        size={18}
-        color={props.danger ? colors.error : colors.textMuted}
-      />
-      <Text style={[menuStyles.label, props.danger && menuStyles.labelDanger]}>
-        {props.label}
+      <Ionicons name={icon} size={18} color={danger ? colors.error : colors.textMuted} />
+      <Text style={[menuStyles.label, { color: danger ? colors.error : colors.textWhite }]}>
+        {label}
       </Text>
     </View>
-    {props.danger !== true && (
-      <Ionicons name="chevron-forward" size={18} color={colors.textMuted} />
-    )}
+    {!danger && <Ionicons name="chevron-forward" size={18} color={colors.textMuted} />}
   </TouchableOpacity>
 );
 
 const menuStyles = StyleSheet.create({
-  row: {
-    flexDirection:     'row',
-    alignItems:        'center',
-    justifyContent:    'space-between',
-    backgroundColor:   'rgba(26, 43, 66, 0.85)',
-    borderRadius:      radius.md,
-    borderWidth:       1,
-    borderColor:       colors.border,
-    paddingVertical:   14,
-    paddingHorizontal: spacing.md,
-  },
-  left:        { flexDirection: 'row', alignItems: 'center', gap: spacing.md },
-  label:       { fontFamily: fonts.regular, fontSize: fontSize.base, color: colors.textWhite },
-  labelDanger: { color: colors.error },
+  row:   { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', borderRadius: radius.md, borderWidth: 1, paddingVertical: 14, paddingHorizontal: spacing.md },
+  left:  { flexDirection: 'row', alignItems: 'center', gap: spacing.md },
+  label: { fontFamily: fonts.regular, fontSize: fontSize.base },
 });
 
-// ---------------------------------------------------------------
-// Main ProfileScreen component
-// ---------------------------------------------------------------
+// ── ProfileScreen ─────────────────────────────────────────────
 export default function ProfileScreen() {
   const navigation = useNavigation<Nav>();
   const { logout } = useAuth();
+  const { colors, lightMode, setLightMode } = useTheme();
+
+  const [settingsOpen,     setSettingsOpen]     = useState(false);
+  const [isSaving,         setIsSaving]         = useState(false);
+  const [defaultBiometric, setDefaultBiometric] = useState<'fingerprint' | 'face'>('fingerprint');
+  const [draftBiometric,   setDraftBiometric]   = useState<'fingerprint' | 'face'>('fingerprint');
+  const [draftLightMode,   setDraftLightMode]   = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const saved = await AsyncStorage.getItem(SETTINGS_BIOMETRIC_KEY);
+        if (saved === 'face' || saved === 'fingerprint') {
+          setDefaultBiometric(saved);
+          setDraftBiometric(saved);
+        }
+      } catch {}
+    };
+    load();
+  }, []);
+
+  const openSettings = () => {
+    setDraftBiometric(defaultBiometric);
+    setDraftLightMode(lightMode);
+    setSettingsOpen(true);
+  };
+
+  const handleSaveSettings = async () => {
+    setIsSaving(true);
+    try {
+      await AsyncStorage.setItem(SETTINGS_BIOMETRIC_KEY, draftBiometric);
+      await setLightMode(draftLightMode);
+      setDefaultBiometric(draftBiometric);
+      setSettingsOpen(false);
+      Alert.alert(
+        'Settings Saved',
+        `Default biometric: ${draftBiometric === 'face' ? 'Face ID' : 'Fingerprint'}.\n` +
+        `Appearance: ${draftLightMode ? 'Light Mode' : 'Dark Mode'}.`,
+      );
+    } catch {
+      Alert.alert('Error', 'Could not save settings. Please try again.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
 
   const handleLogout = async () => {
     await logout();
@@ -124,72 +151,208 @@ export default function ProfileScreen() {
   };
 
   return (
-    <MainFrame header="home">
-      <View style={styles.scrollContent}>
-          {/* ── Avatar + name ───────────────────────────────────── */}
-          <View style={styles.avatarBlock}>
-            <View style={styles.avatarCircle}>
-              <Ionicons name="person" size={52} color="#8a9bb8" />
-            </View>
-            <Text style={styles.name}>{CONTRACTOR.name}</Text>
-            <Text style={styles.metaText}>Contractor ID: {CONTRACTOR.contractorId}</Text>
-            <Text style={styles.metaText}>Vendor: {CONTRACTOR.vendor}</Text>
-          </View>
+    <MainFrame header="home" headerMenu={['Menu2', ['Profile']]}>
+      <StatusBar
+        barStyle={lightMode ? 'dark-content' : 'light-content'}
+        backgroundColor="transparent"
+        translucent
+      />
 
-          {/* ── Contact info ─────────────────────────────────────── */}
-          <View style={styles.section}>
-            <InfoRow icon="camera-outline"   label="Email"   value={CONTRACTOR.email}   />
-            <InfoRow icon="call-outline"     label="Phone"   value={CONTRACTOR.phone}   />
-            <InfoRow icon="location-outline" label="Address" value={CONTRACTOR.address} />
-          </View>
-
-          {/* ── Menu rows ────────────────────────────────────────── */}
-          <View style={styles.section}>
-            <MenuRow
-              icon="ribbon-outline"
-              label="License"
-              onPress={() => navigation.navigate('LicenseDetails')}
-            />
-            <MenuRow
-              icon="settings-outline"
-              label="Settings"
-              onPress={() => { /* TODO: navigate to Settings */ }}
-            />
-            <MenuRow
-              icon="log-out-outline"
-              label="Logout"
-              onPress={handleLogout}
-              danger
-            />
-          </View>
-
+      {/* ── Avatar + name ─────────────────────────────── */}
+      <View style={[styles.avatarBlock, { backgroundColor: lightMode ? '#dde6f0' : '#0f1d33' }]}>
+        <View style={[styles.avatarCircle, { backgroundColor: lightMode ? '#c8d8ea' : '#1e2d45' }]}>
+          <Ionicons name="person" size={52} color={lightMode ? '#4a6b8a' : '#8a9bb8'} />
+        </View>
+        <Text style={[styles.name, { color: colors.textWhite }]}>{CONTRACTOR.name}</Text>
+        <Text style={[styles.metaText, { color: colors.textMuted }]}>Contractor ID: {CONTRACTOR.contractorId}</Text>
+        <Text style={[styles.metaText, { color: colors.textMuted }]}>Vendor: {CONTRACTOR.vendor}</Text>
       </View>
+
+      {/* ── Contact info ──────────────────────────────── */}
+      <View style={styles.section}>
+        <InfoRow icon="mail-outline"     label="Email"   value={CONTRACTOR.email}   colors={colors} />
+        <InfoRow icon="call-outline"     label="Phone"   value={CONTRACTOR.phone}   colors={colors} />
+        <InfoRow icon="location-outline" label="Address" value={CONTRACTOR.address} colors={colors} />
+      </View>
+
+      {/* ── Menu rows ─────────────────────────────────── */}
+      <View style={styles.section}>
+        <MenuRow
+          icon="ribbon-outline"
+          label="License"
+          onPress={() => navigation.navigate('LicenseDetails')}
+          colors={colors}
+        />
+        <MenuRow
+          icon="time-outline"
+          label="Task History"
+          onPress={() => navigation.navigate('TaskHistory')}
+          colors={colors}
+        />
+        <MenuRow
+          icon="settings-outline"
+          label="Settings"
+          onPress={openSettings}
+          colors={colors}
+        />
+        <MenuRow
+          icon="log-out-outline"
+          label="Logout"
+          onPress={handleLogout}
+          danger
+          colors={colors}
+        />
+      </View>
+
+      {/* ── Settings Modal ────────────────────────────── */}
+      <Modal
+        visible={settingsOpen}
+        animationType="slide"
+        transparent
+        onRequestClose={() => setSettingsOpen(false)}
+      >
+        <TouchableOpacity
+          style={modalStyles.backdrop}
+          activeOpacity={1}
+          onPress={() => setSettingsOpen(false)}
+        />
+
+        <View style={[modalStyles.sheet, { backgroundColor: colors.card }]}>
+          <View style={[modalStyles.handle, { backgroundColor: colors.border }]} />
+
+          <View style={modalStyles.sheetHeader}>
+            <Text style={[modalStyles.sheetTitle, { color: colors.textWhite }]}>Settings</Text>
+            <TouchableOpacity onPress={() => setSettingsOpen(false)} activeOpacity={0.7}>
+              <Ionicons name="close" size={22} color={colors.textMuted} />
+            </TouchableOpacity>
+          </View>
+
+          {/* Default biometric */}
+          <Text style={[modalStyles.sectionLabel, { color: colors.textMuted }]}>DEFAULT BIOMETRIC</Text>
+          <Text style={[modalStyles.sectionHint, { color: colors.textMuted }]}>
+            Which method should the app prompt you with first when logging in?
+          </Text>
+
+          <View style={modalStyles.biometricRow}>
+            {(['fingerprint', 'face'] as const).map(method => (
+              <TouchableOpacity
+                key={method}
+                style={[
+                  modalStyles.biometricBtn,
+                  { backgroundColor: colors.background, borderColor: colors.border },
+                  draftBiometric === method && { borderColor: colors.primary, backgroundColor: colors.primaryFaint },
+                ]}
+                onPress={() => setDraftBiometric(method)}
+                activeOpacity={0.8}
+              >
+                <Ionicons
+                  name={method === 'fingerprint' ? 'finger-print' : 'scan-outline'}
+                  size={28}
+                  color={draftBiometric === method ? colors.primary : colors.textMuted}
+                />
+                <Text style={[
+                  modalStyles.biometricLabel,
+                  { color: draftBiometric === method ? colors.primary : colors.textMuted },
+                  draftBiometric === method && { fontFamily: fonts.bold },
+                ]}>
+                  {method === 'fingerprint' ? 'Fingerprint' : 'Face ID'}
+                </Text>
+                {draftBiometric === method && (
+                  <View style={[modalStyles.checkBadge, { backgroundColor: colors.primary }]}>
+                    <Ionicons name="checkmark" size={12} color="#fff" />
+                  </View>
+                )}
+              </TouchableOpacity>
+            ))}
+          </View>
+
+          {/* Appearance */}
+          <Text style={[modalStyles.sectionLabel, { color: colors.textMuted, marginTop: spacing.xl }]}>APPEARANCE</Text>
+          <Text style={[modalStyles.sectionHint, { color: colors.textMuted }]}>
+            Switch between dark and light mode.
+          </Text>
+
+          <View style={[modalStyles.appearanceRow, { backgroundColor: colors.background, borderColor: colors.border }]}>
+            <View style={modalStyles.appearanceLeft}>
+              <Ionicons
+                name={draftLightMode ? 'sunny-outline' : 'moon-outline'}
+                size={22}
+                color={colors.primary}
+              />
+              <View>
+                <Text style={[modalStyles.appearanceTitle, { color: colors.textWhite }]}>
+                  {draftLightMode ? 'Light Mode' : 'Dark Mode'}
+                </Text>
+                <Text style={[modalStyles.appearanceHint, { color: colors.textMuted }]}>
+                  {draftLightMode ? 'Light theme active' : 'Dark theme active'}
+                </Text>
+              </View>
+            </View>
+            <Switch
+              value={draftLightMode}
+              onValueChange={setDraftLightMode}
+              trackColor={{ false: colors.border, true: colors.primary }}
+              thumbColor="#ffffff"
+            />
+          </View>
+
+          {/* Save button */}
+          <TouchableOpacity
+            style={[
+              modalStyles.saveBtn,
+              { backgroundColor: isSaving ? colors.cardAlt : colors.primary },
+            ]}
+            onPress={handleSaveSettings}
+            activeOpacity={0.85}
+            disabled={isSaving}
+          >
+            <Ionicons name="checkmark-circle-outline" size={18} color="#fff" />
+            <Text style={modalStyles.saveBtnText}>
+              {isSaving ? 'Saving…' : 'Save Settings'}
+            </Text>
+          </TouchableOpacity>
+
+          <View style={[modalStyles.noteBox, { backgroundColor: colors.background, borderColor: colors.border }]}>
+            <Ionicons name="information-circle-outline" size={16} color={colors.textMuted} />
+            <Text style={[modalStyles.noteText, { color: colors.textMuted }]}>
+              Biometric preference takes effect on next login. Light mode applies to the whole app immediately.
+            </Text>
+          </View>
+
+        </View>
+      </Modal>
+
     </MainFrame>
   );
 }
 
 const styles = StyleSheet.create({
-  scrollContent:   { gap: spacing.md, paddingBottom: spacing.xl },
 
-  avatarBlock: {
-    alignItems:        'center',
-    backgroundColor:   'rgba(15, 29, 51, 0.75)', // semi-transparent so bg image shows
-    paddingVertical:   spacing.xl,
-    paddingHorizontal: spacing.md,
-    gap:               spacing.xs,
-    marginBottom:      spacing.sm,
-  },
-  avatarCircle: {
-    width:           90,
-    height:          90,
-    borderRadius:    45,
-    backgroundColor: 'rgba(30, 45, 69, 0.9)',
-    alignItems:      'center',
-    justifyContent:  'center',
-    marginBottom:    spacing.sm,
-  },
-  name:     { fontFamily: fonts.bold,    fontSize: fontSize.xl, color: colors.textWhite },
-  metaText: { fontFamily: fonts.regular, fontSize: fontSize.sm, color: colors.textMuted },
+  avatarBlock:  { alignItems: 'center', paddingVertical: spacing.xl, paddingHorizontal: spacing.md, gap: spacing.xs, width: '100%', marginBottom: spacing.sm },
+  avatarCircle: { width: 90, height: 90, borderRadius: 45, alignItems: 'center', justifyContent: 'center', marginBottom: spacing.sm },
+  name:         { fontFamily: fonts.bold,    fontSize: fontSize.xl },
+  metaText:     { fontFamily: fonts.regular, fontSize: fontSize.sm },
+  section:      { gap: spacing.sm, paddingHorizontal: spacing.md, width: '100%', marginBottom: spacing.sm },
+});
 
-  section: { gap: spacing.sm, paddingHorizontal: spacing.md },
+const modalStyles = StyleSheet.create({
+  backdrop:        { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)' },
+  sheet:           { borderTopLeftRadius: 24, borderTopRightRadius: 24, paddingHorizontal: spacing.lg, paddingBottom: spacing.xl, paddingTop: spacing.sm },
+  handle:          { width: 40, height: 4, borderRadius: 2, alignSelf: 'center', marginBottom: spacing.md },
+  sheetHeader:     { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: spacing.lg },
+  sheetTitle:      { fontFamily: fonts.bold, fontSize: fontSize.lg },
+  sectionLabel:    { fontFamily: fonts.bold, fontSize: fontSize.xs, letterSpacing: 1.2, marginBottom: spacing.xs },
+  sectionHint:     { fontFamily: fonts.regular, fontSize: fontSize.sm, lineHeight: 20, marginBottom: spacing.md },
+  biometricRow:    { flexDirection: 'row', gap: spacing.md },
+  biometricBtn:    { flex: 1, alignItems: 'center', gap: spacing.sm, paddingVertical: spacing.lg, borderRadius: radius.md, borderWidth: 2, position: 'relative' },
+  biometricLabel:  { fontFamily: fonts.regular, fontSize: fontSize.sm },
+  checkBadge:      { position: 'absolute', top: 8, right: 8, width: 20, height: 20, borderRadius: 10, alignItems: 'center', justifyContent: 'center' },
+  appearanceRow:   { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', borderRadius: radius.md, borderWidth: 1, paddingVertical: spacing.md, paddingHorizontal: spacing.md, marginBottom: spacing.md },
+  appearanceLeft:  { flexDirection: 'row', alignItems: 'center', gap: spacing.md, flex: 1 },
+  appearanceTitle: { fontFamily: fonts.bold,    fontSize: fontSize.base },
+  appearanceHint:  { fontFamily: fonts.regular, fontSize: fontSize.xs, marginTop: 2 },
+  saveBtn:         { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: spacing.sm, borderRadius: radius.md, paddingVertical: 15, marginBottom: spacing.md, marginTop: spacing.sm },
+  saveBtnText:     { fontFamily: fonts.bold, color: '#fff', fontSize: fontSize.base, letterSpacing: 0.5 },
+  noteBox:         { flexDirection: 'row', alignItems: 'flex-start', gap: spacing.sm, borderRadius: radius.md, borderWidth: 1, padding: spacing.md },
+  noteText:        { flex: 1, fontFamily: fonts.regular, fontSize: fontSize.xs, lineHeight: 18 },
 });

--- a/frontend/field-force-contractor/screens/SplashScreen.tsx
+++ b/frontend/field-force-contractor/screens/SplashScreen.tsx
@@ -1,44 +1,78 @@
-import {FC, useEffect, useRef, useState} from "react"
-import { useNavigation } from "@react-navigation/native"
+// SplashScreen.tsx  —  Jonathan
+//
+// Shows the Field Force logo for 3 seconds on app launch, then routes
+// based on whether the user has a valid existing session:
+//
+//   Valid token found → Home   (user stays logged in, skips login)
+//   No token / expired → Login (user must log in again)
+//
+// ── IMPORTANT: WHY replace() AND NOT navigate() ───────────────────────────────
+// Using navigate() leaves SplashScreen in the navigation stack. If anything
+// later changes isAuthenticated (e.g. login() being called after biometrics),
+// the useEffect would fire again, start a new timer, and navigate the user back
+// to Home mid-session — pulling them off whatever screen they were on.
+//
+// replace() removes SplashScreen from the stack entirely when it routes. It
+// can never fire again after that because it is no longer mounted.
+//
+// A hasNavigated ref provides a second safety net: even if the effect fires
+// multiple times before navigation completes, only one navigation happens.
+// ──────────────────────────────────────────────────────────────────────────────
+
+import { FC, useEffect, useRef } from "react"
+import { useNavigation }          from "@react-navigation/native"
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { RootStackParamList } from "@/App"
-import { MainFrame } from "@/components/MainFrame";
-import {View,Image} from "react-native"
-import { Styles } from "@/constants/Styles";
-import { Assets } from "@/constants/Assets";
-import { useAuth } from "@/contexts/AuthContext";
+import { RootStackParamList }     from "@/App"
+import { MainFrame }              from "@/components/MainFrame";
+import { View, Image }            from "react-native"
+import { Styles }                 from "@/constants/Styles";
+import { Assets }                 from "@/constants/Assets";
+import { useAuth }                from "@/contexts/AuthContext";
 
-export const SplashScreen:FC = () =>{
-const nav = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
-const { isAuthenticated, isLoading } = useAuth()
-const [splashDone, setSplashDone] = useState(false)
-const navigated = useRef(false)
+export const SplashScreen: FC = () => {
+  const nav  = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const { isAuthenticated, isLoading } = useAuth();
 
- useEffect(() =>{
-  const timer = setTimeout(() => setSplashDone(true), 2500)
-  return () => clearTimeout(timer)
- },[])
+  // Prevents multiple navigations if the effect fires more than once
+  const hasNavigated = useRef(false);
 
- useEffect(() =>{
-  if (splashDone && !isLoading && !navigated.current) {
-   navigated.current = true
-   nav.navigate(isAuthenticated ? "Dashboard" : "Login")
-  }
- },[splashDone, isLoading, isAuthenticated])
+  const SPLASH_TIME = 3000; // 3 seconds to show the logo
 
- return(<>
- 
-  <MainFrame strip="all">
+  useEffect(() => {
+    // Don't start the timer until AuthContext has finished reading SecureStore
+    if (isLoading) return;
+    // Don't navigate again if we already have
+    if (hasNavigated.current) return;
 
-    <View style={Styles.SplashScreen.Block}>
+    const timer = setTimeout(() => {
+      if (hasNavigated.current) return;
+      hasNavigated.current = true;
 
-        <Image source={Assets.logos.FieldForceLogo} style={Styles.SplashScreen.LogoImage}/>
-        <Image source={Assets.logos.FieldForceLogoText} style={Styles.SplashScreen.LogoText}/>
-          
-    </View>
+      if (isAuthenticated) {
+        // Valid unexpired token — skip login entirely
+        // replace() removes SplashScreen from the stack so it can never
+        // fire navigation again after the user is in the app
+        nav.replace('Home' as any);
+      } else {
+        // No token or expired — go to Login
+        nav.replace('Login' as any);
+      }
+    }, SPLASH_TIME);
 
-  </MainFrame>
- 
- </>)
+    return () => clearTimeout(timer);
 
-}
+    // Only isLoading is a dependency — we intentionally do NOT include
+    // isAuthenticated here. We read it once when isLoading becomes false.
+    // If isAuthenticated were a dependency, any later call to login() would
+    // re-trigger this effect and navigate the user mid-session.
+  }, [isLoading]);
+
+  return (
+    <MainFrame header="none" headerMenu={["none"]} footerMenu={["none"]}>
+      <View style={Styles.SplashScreen.Block}>
+        <Image source={Assets.logos.FieldForceLogo}     style={Styles.SplashScreen.LogoImage} />
+        <Image source={Assets.logos.FieldForceLogoText} style={Styles.SplashScreen.LogoText}  />
+      </View>
+    </MainFrame>
+  );
+};

--- a/frontend/field-force-contractor/screens/TaskHistoryScreen.tsx
+++ b/frontend/field-force-contractor/screens/TaskHistoryScreen.tsx
@@ -1,0 +1,463 @@
+// TaskHistoryScreen.tsx  —  Troy
+//
+// Shows the contractor's full task history pulled from their profile.
+// Split into two sections:
+//
+//   Completed Tasks   — tasks the contractor fully completed and submitted
+//   Incomplete Tasks  — tasks they were assigned to and did some work on
+//                       but did not personally complete (handed off, removed,
+//                       or the job was reassigned before submission)
+//
+// Both sections are read-only reference records. The contractor cannot
+// modify anything here — it is purely for their own records and in case
+// a vendor disputes or flags a ticket.
+//
+// TODO: Replace MOCK_HISTORY with real data fetched from the backend API
+// once the endpoint is available. The shape of each record is documented
+// below so the backend team knows what fields to return.
+
+import { useState } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  StatusBar,
+} from 'react-native';
+import { Ionicons }      from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+import { RootStackParamList } from '../App';
+import { MainFrame }          from '../components/MainFrame';
+import { colors, spacing, radius, fontSize, fonts } from '../constants/theme';
+
+type Nav = NativeStackNavigationProp<RootStackParamList, 'TaskHistory'>;
+
+// ── Data shape ────────────────────────────────────────────────────────────────
+// Each history record represents one task the contractor was involved with.
+// The backend should return an array of these per contractor.
+
+type TaskRecord = {
+  id:          string;
+  title:       string;
+  vendor:      string;
+  location:    string;
+  date:        string;   // display-formatted date string e.g. "Mar 20, 2026"
+  status:      'Completed' | 'Incomplete';
+  reason?:     string;   // only for incomplete — why it was not finished
+  ticketRef:   string;   // ticket / work order reference number
+};
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+// Replace with a real API call once the backend endpoint is ready.
+// Sorted newest first within each section.
+
+const MOCK_HISTORY: TaskRecord[] = [
+  {
+    id:        'H-001',
+    title:     'Safety Equipment Check',
+    vendor:    'Ex-Way Logistics',
+    location:  '1234 Industrial Park Blvd, Austin, TX',
+    date:      'Mar 20, 2026',
+    status:    'Completed',
+    ticketRef: 'WO-2026-001',
+  },
+  {
+    id:        'H-002',
+    title:     'Rooftop HVAC Inspection',
+    vendor:    'Ex-Way Logistics',
+    location:  '890 Commerce Dr, Houston, TX',
+    date:      'Mar 18, 2026',
+    status:    'Completed',
+    ticketRef: 'WO-2026-002',
+  },
+  {
+    id:        'H-003',
+    title:     'Pipeline Pressure Test',
+    vendor:    'Gulf South Contractors',
+    location:  '4400 Refinery Rd, Beaumont, TX',
+    date:      'Mar 15, 2026',
+    status:    'Completed',
+    ticketRef: 'WO-2026-003',
+  },
+  {
+    id:        'H-004',
+    title:     'Electrical Panel Audit',
+    vendor:    'Ex-Way Logistics',
+    location:  '1234 Industrial Park Blvd, Austin, TX',
+    date:      'Mar 20, 2026',
+    status:    'Incomplete',
+    reason:    'Task reassigned — contractor reached mandated rest period before completion.',
+    ticketRef: 'WO-2026-001',
+  },
+  {
+    id:        'H-005',
+    title:     'Water Tank Delivery — Route 7',
+    vendor:    'Gulf South Contractors',
+    location:  '220 Tank Farm Rd, Corpus Christi, TX',
+    date:      'Mar 12, 2026',
+    status:    'Incomplete',
+    reason:    'Vehicle issue reported on route. Task handed off to another contractor.',
+    ticketRef: 'WO-2026-004',
+  },
+];
+
+// ── TaskCard — one history entry ──────────────────────────────────────────────
+type TaskCardProps = {
+  record:    TaskRecord;
+  isOpen:    boolean;
+  onToggle:  () => void;
+};
+
+const TaskCard = ({ record, isOpen, onToggle }: TaskCardProps) => {
+  const isComplete = record.status === 'Completed';
+
+  return (
+    <TouchableOpacity
+      style={[
+        cardStyles.container,
+        isOpen && cardStyles.containerOpen,
+      ]}
+      onPress={onToggle}
+      activeOpacity={0.8}
+    >
+      {/* Always-visible summary row */}
+      <View style={cardStyles.row}>
+        {/* Status dot */}
+        <View style={[
+          cardStyles.dot,
+          { backgroundColor: isComplete ? colors.success : colors.warning },
+        ]} />
+
+        <View style={cardStyles.info}>
+          <Text style={cardStyles.title} numberOfLines={isOpen ? undefined : 1}>
+            {record.title}
+          </Text>
+          <Text style={cardStyles.meta}>{record.vendor}  •  {record.date}</Text>
+        </View>
+
+        {/* Status badge */}
+        <View style={[
+          cardStyles.badge,
+          { backgroundColor: isComplete ? 'rgba(52,211,153,0.12)' : 'rgba(245,158,11,0.12)' },
+        ]}>
+          <Text style={[
+            cardStyles.badgeText,
+            { color: isComplete ? colors.success : colors.warning },
+          ]}>
+            {isComplete ? 'Done' : 'Incomplete'}
+          </Text>
+        </View>
+
+        <Ionicons
+          name={isOpen ? 'chevron-up' : 'chevron-forward'}
+          size={16}
+          color={colors.textMuted}
+          style={cardStyles.chevron}
+        />
+      </View>
+
+      {/* Expanded detail section */}
+      {isOpen && (
+        <View style={cardStyles.detail}>
+          <View style={cardStyles.detailRow}>
+            <Ionicons name="document-text-outline" size={14} color={colors.textMuted} />
+            <Text style={cardStyles.detailLabel}>Ticket Ref</Text>
+            <Text style={cardStyles.detailValue}>{record.ticketRef}</Text>
+          </View>
+
+          <View style={cardStyles.detailRow}>
+            <Ionicons name="location-outline" size={14} color={colors.textMuted} />
+            <Text style={cardStyles.detailLabel}>Location</Text>
+            <Text style={cardStyles.detailValue} numberOfLines={2}>{record.location}</Text>
+          </View>
+
+          {/* Show reason only for incomplete tasks */}
+          {!isComplete && record.reason && (
+            <View style={[cardStyles.reasonBox]}>
+              <Ionicons name="information-circle-outline" size={14} color={colors.warning} />
+              <Text style={cardStyles.reasonText}>{record.reason}</Text>
+            </View>
+          )}
+        </View>
+      )}
+    </TouchableOpacity>
+  );
+};
+
+const cardStyles = StyleSheet.create({
+  container: {
+    backgroundColor:   colors.card,
+    borderRadius:      radius.md,
+    borderWidth:       1,
+    borderColor:       colors.border,
+    paddingVertical:   spacing.md,
+    paddingHorizontal: spacing.md,
+    gap:               spacing.sm,
+  },
+  containerOpen: {
+    borderColor: colors.borderActive,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems:    'center',
+    gap:           spacing.sm,
+  },
+  dot: {
+    width:        8,
+    height:       8,
+    borderRadius: 4,
+    flexShrink:   0,
+  },
+  info: { flex: 1 },
+  title: {
+    fontFamily: fonts.bold,
+    fontSize:   fontSize.base,
+    color:      colors.textWhite,
+    marginBottom: 2,
+  },
+  meta: {
+    fontFamily: fonts.regular,
+    fontSize:   fontSize.xs,
+    color:      colors.textMuted,
+  },
+  badge: {
+    borderRadius:      radius.sm,
+    paddingVertical:   3,
+    paddingHorizontal: 8,
+    flexShrink:        0,
+  },
+  badgeText: {
+    fontFamily: fonts.bold,
+    fontSize:   fontSize.xs,
+  },
+  chevron: { flexShrink: 0 },
+
+  detail: {
+    gap:              spacing.sm,
+    paddingTop:       spacing.sm,
+    borderTopWidth:   1,
+    borderTopColor:   colors.border,
+    marginTop:        spacing.xs,
+  },
+  detailRow: {
+    flexDirection: 'row',
+    alignItems:    'flex-start',
+    gap:           spacing.sm,
+  },
+  detailLabel: {
+    fontFamily: fonts.regular,
+    fontSize:   fontSize.xs,
+    color:      colors.textMuted,
+    width:      72,
+    flexShrink: 0,
+  },
+  detailValue: {
+    fontFamily: fonts.regular,
+    fontSize:   fontSize.sm,
+    color:      colors.textLight,
+    flex:       1,
+  },
+  reasonBox: {
+    flexDirection:   'row',
+    alignItems:      'flex-start',
+    gap:             spacing.sm,
+    backgroundColor: 'rgba(245,158,11,0.08)',
+    borderWidth:     1,
+    borderColor:     colors.warning,
+    borderRadius:    radius.sm,
+    padding:         spacing.sm,
+    marginTop:       spacing.xs,
+  },
+  reasonText: {
+    flex:       1,
+    fontFamily: fonts.regular,
+    fontSize:   fontSize.xs,
+    color:      colors.textLight,
+    lineHeight: 18,
+  },
+});
+
+// ── Section header ────────────────────────────────────────────────────────────
+const SectionHeader = ({ title, count, icon }: {
+  title: string; count: number; icon: any;
+}) => (
+  <View style={sectionStyles.row}>
+    <Ionicons name={icon} size={16} color={colors.primary} />
+    <Text style={sectionStyles.title}>{title}</Text>
+    <View style={sectionStyles.countBadge}>
+      <Text style={sectionStyles.count}>{count}</Text>
+    </View>
+  </View>
+);
+
+const sectionStyles = StyleSheet.create({
+  row: {
+    flexDirection:  'row',
+    alignItems:     'center',
+    gap:            spacing.sm,
+    paddingBottom:  spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    marginBottom:   spacing.sm,
+  },
+  title: {
+    flex:          1,
+    fontFamily:    fonts.bold,
+    fontSize:      fontSize.xs,
+    color:         colors.textMuted,
+    letterSpacing: 1.2,
+  },
+  countBadge: {
+    backgroundColor: colors.primaryFaint,
+    borderRadius:    10,
+    paddingVertical: 2,
+    paddingHorizontal: 8,
+  },
+  count: {
+    fontFamily: fonts.bold,
+    fontSize:   fontSize.xs,
+    color:      colors.primary,
+  },
+});
+
+// ── TaskHistoryScreen ─────────────────────────────────────────────────────────
+export default function TaskHistoryScreen() {
+  const navigation = useNavigation<Nav>();
+
+  // Tracks which card is expanded — null means all collapsed
+  const [openCard, setOpenCard] = useState<string | null>(null);
+
+  const toggleCard = (id: string) => {
+    setOpenCard(prev => (prev === id ? null : id));
+  };
+
+  const completed  = MOCK_HISTORY.filter(r => r.status === 'Completed');
+  const incomplete = MOCK_HISTORY.filter(r => r.status === 'Incomplete');
+
+  return (
+    <MainFrame header="home" headerMenu={['Menu2', ['Task History']]}>
+      <StatusBar barStyle="light-content" backgroundColor="transparent" translucent />
+
+      {/* Summary strip */}
+      <View style={styles.summaryStrip}>
+        <View style={styles.summaryItem}>
+          <Text style={styles.summaryNumber}>{completed.length}</Text>
+          <Text style={styles.summaryLabel}>Completed</Text>
+        </View>
+        <View style={styles.summaryDivider} />
+        <View style={styles.summaryItem}>
+          <Text style={[styles.summaryNumber, { color: colors.warning }]}>
+            {incomplete.length}
+          </Text>
+          <Text style={styles.summaryLabel}>Incomplete</Text>
+        </View>
+        <View style={styles.summaryDivider} />
+        <View style={styles.summaryItem}>
+          <Text style={styles.summaryNumber}>{MOCK_HISTORY.length}</Text>
+          <Text style={styles.summaryLabel}>Total</Text>
+        </View>
+      </View>
+
+      {/* ── Completed tasks ────────────────────────────── */}
+      <View style={styles.section}>
+        <SectionHeader
+          title="COMPLETED TASKS"
+          count={completed.length}
+          icon="checkmark-circle-outline"
+        />
+        {completed.length === 0 ? (
+          <Text style={styles.emptyText}>No completed tasks on record yet.</Text>
+        ) : (
+          completed.map(record => (
+            <TaskCard
+              key={record.id}
+              record={record}
+              isOpen={openCard === record.id}
+              onToggle={() => toggleCard(record.id)}
+            />
+          ))
+        )}
+      </View>
+
+      {/* ── Incomplete tasks ───────────────────────────── */}
+      <View style={styles.section}>
+        <SectionHeader
+          title="INCOMPLETE TASKS"
+          count={incomplete.length}
+          icon="time-outline"
+        />
+        <Text style={styles.sectionNote}>
+          Tasks you were assigned to and contributed to but did not personally complete. Kept here for your records in case a vendor follows up.
+        </Text>
+        {incomplete.length === 0 ? (
+          <Text style={styles.emptyText}>No incomplete tasks on record.</Text>
+        ) : (
+          incomplete.map(record => (
+            <TaskCard
+              key={record.id}
+              record={record}
+              isOpen={openCard === record.id}
+              onToggle={() => toggleCard(record.id)}
+            />
+          ))
+        )}
+      </View>
+
+    </MainFrame>
+  );
+}
+
+const styles = StyleSheet.create({
+  // Summary strip at the top
+  summaryStrip: {
+    flexDirection:     'row',
+    alignItems:        'center',
+    justifyContent:    'space-evenly',
+    backgroundColor:   colors.card,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    paddingVertical:   spacing.md,
+    width:             '100%',
+    marginBottom:      spacing.md,
+  },
+  summaryItem:   { alignItems: 'center', gap: 2 },
+  summaryNumber: {
+    fontFamily: fonts.bold,
+    fontSize:   fontSize.xl,
+    color:      colors.success,
+  },
+  summaryLabel: {
+    fontFamily: fonts.regular,
+    fontSize:   fontSize.xs,
+    color:      colors.textMuted,
+  },
+  summaryDivider: {
+    width:  1,
+    height: 32,
+    backgroundColor: colors.border,
+  },
+
+  // Section containers
+  section: {
+    gap:               spacing.sm,
+    paddingHorizontal: spacing.md,
+    width:             '100%',
+    marginBottom:      spacing.xl,
+  },
+  sectionNote: {
+    fontFamily: fonts.regular,
+    fontSize:   fontSize.xs,
+    color:      colors.textMuted,
+    lineHeight: 18,
+    marginBottom: spacing.xs,
+  },
+  emptyText: {
+    fontFamily: fonts.regular,
+    fontSize:   fontSize.sm,
+    color:      colors.textMuted,
+    textAlign:  'center',
+    paddingVertical: spacing.lg,
+  },
+});

--- a/frontend/field-force-contractor/screens/TicketDetailScreen.tsx
+++ b/frontend/field-force-contractor/screens/TicketDetailScreen.tsx
@@ -1,15 +1,17 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, TextInput, Modal, Alert, ActivityIndicator } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { MainFrame } from '../components/MainFrame';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { SETTINGS_BIOMETRIC_KEY } from './ProfileScreen';
 
 const DEV_MODE = true;
 
 export default function TicketDetailScreen() {
   const navigation = useNavigation<any>();
   const route = useRoute<any>();
-  const { taskId, assigned } = route.params;
+  const { taskId } = route.params;
 
   const [taskStatus, setTaskStatus] = useState<'not_started' | 'in_progress' | 'ready_to_submit'>('not_started');
   const [notes, setNotes] = useState('');
@@ -22,6 +24,23 @@ export default function TicketDetailScreen() {
 
   const pinRefs = useRef<(TextInput | null)[]>([null, null, null, null, null, null]);
 
+  // ── Load saved biometric preference ────────────────────────────────────────
+  // Reads the preference the user set in ProfileScreen → Settings so the
+  // correct method is pre-selected when the verification modal opens.
+  useEffect(() => {
+    const loadPreference = async () => {
+      try {
+        const saved = await AsyncStorage.getItem(SETTINGS_BIOMETRIC_KEY);
+        if (saved === 'face' || saved === 'fingerprint') {
+          setSelectedMethod(saved);
+        }
+      } catch {
+        // Fall back to fingerprint default if read fails
+      }
+    };
+    loadPreference();
+  }, []);
+
   const task = {
     id: taskId,
     title: 'Install Gas Pump at Station #42',
@@ -31,7 +50,6 @@ export default function TicketDetailScreen() {
     description: 'Install new gas pump model XR-500 at station #42. Ensure proper connection to underground tank and test all safety mechanisms before completion.',
     photosRequired: 3,
     photosSubmitted: taskStatus === 'ready_to_submit' ? 3 : 0,
-    pointOfContact: { name: 'John Martinez', phone: '+1 (555) 012-3456' },
   };
 
   const toggleListening = () => {
@@ -122,18 +140,19 @@ export default function TicketDetailScreen() {
     }, 1500);
   };
 
-  const handleAcceptTask = () => {
-    // TODO: API call to accept task
-    navigation.goBack();
-  };
-
-  const handleDeclineTask = () => {
-    // TODO: API call to decline task
-    navigation.goBack();
-  };
-
   return (
     <MainFrame header='home'>
+
+      {/* ── Back Header ── */}
+      <View style={styles.backHeader}>
+        <TouchableOpacity style={styles.backBtn} onPress={() => navigation.goBack()}>
+          <Ionicons name="arrow-back" size={20} color="white" />
+        </TouchableOpacity>
+        <View style={styles.backHeaderText}>
+          <Text style={styles.backTitle}>Task Details</Text>
+          <Text style={styles.backSubtitle}>ID: #{task.id}</Text>
+        </View>
+      </View>
 
       {/* ── Task Title + Status ── */}
       <View style={styles.section}>
@@ -150,20 +169,6 @@ export default function TicketDetailScreen() {
           </Text>
         </View>
       </View>
-
-      {/* ── Accept and Decline Buttons ── */}
-      {!assigned && (
-        <View style={styles.assignRow}>
-          <TouchableOpacity style={styles.acceptBtn} onPress={handleAcceptTask}>
-            <Ionicons name="checkmark" size={12} color="white" />
-            <Text style={styles.btnText}>Accept</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.declineBtn} onPress={handleDeclineTask}>
-            <Ionicons name="close" size={12} color="white" />
-            <Text style={styles.btnText}>Decline</Text>
-          </TouchableOpacity>
-        </View>
-      )}
 
       {/* ── Location ── */}
       <View style={styles.infoCard}>
@@ -184,18 +189,6 @@ export default function TicketDetailScreen() {
         <View style={styles.infoText}>
           <Text style={styles.infoLabel}>Deadline</Text>
           <Text style={styles.infoValue}>{task.deadline}</Text>
-        </View>
-      </View>
-
-      {/* ── Point of Contact ── */}
-      <View style={styles.infoCard}>
-        <View style={styles.infoIcon}>
-          <Ionicons name="person" size={18} color="#ff8c00" />
-        </View>
-        <View style={styles.infoText}>
-          <Text style={styles.infoLabel}>Point of Contact</Text>
-          <Text style={styles.infoValue}>{task.pointOfContact.name}</Text>
-          <Text style={styles.taskDetail}>{task.pointOfContact.phone}</Text>
         </View>
       </View>
 
@@ -227,76 +220,71 @@ export default function TicketDetailScreen() {
         </View>
       )}
 
-      {/* ── Photos — only when in progress ── */}
+      {/* ── Photos ── */}
       {taskStatus !== 'not_started' && (
         <View style={styles.card}>
           <View style={styles.cardRow}>
-            <Text style={styles.cardTitle}>Photo Submissions</Text>
+            <Text style={styles.cardTitle}>Photos</Text>
             <Text style={styles.photoCount}>{task.photosSubmitted}/{task.photosRequired}</Text>
           </View>
           <View style={styles.photoRow}>
-            {[...Array(task.photosRequired)].map((_, index) => (
-              <View key={index} style={[
-                styles.photoSlot,
-                index < task.photosSubmitted && styles.photoSlotDone
-              ]}>
+            {[...Array(task.photosRequired)].map((_, i) => (
+              <TouchableOpacity
+                key={i}
+                style={[styles.photoSlot, i < task.photosSubmitted && styles.photoSlotDone]}
+                onPress={handleTakePhoto}
+              >
                 <Ionicons
-                  name={index < task.photosSubmitted ? 'checkmark-circle' : 'camera'}
+                  name={i < task.photosSubmitted ? 'checkmark-circle' : 'camera'}
                   size={24}
-                  color={index < task.photosSubmitted ? '#22c55e' : '#6b7280'}
+                  color={i < task.photosSubmitted ? '#22c55e' : '#6b7280'}
                 />
-              </View>
+              </TouchableOpacity>
             ))}
           </View>
         </View>
       )}
 
-      {/* ── Action Buttons ── */}
+      {/* ── Actions ── */}
       <View style={styles.actions}>
-        {taskStatus === 'not_started' && assigned && (
+        {taskStatus === 'not_started' && (
           <TouchableOpacity style={styles.btnPrimary} onPress={handleStartTask}>
-            <Ionicons name="play" size={20} color="white" />
+            <Ionicons name="play-circle" size={20} color="white" />
             <Text style={styles.btnText}>Start Task</Text>
           </TouchableOpacity>
         )}
-
         {taskStatus === 'in_progress' && (
           <>
-            <TouchableOpacity style={styles.btnPrimary} onPress={handleTakePhoto}>
-              <Ionicons name="camera" size={20} color="white" />
-              <Text style={styles.btnText}>Take Photo</Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.btnOutline} onPress={() => navigation.navigate('UploadPhoto' as never, { taskId } as never)}>
-              <Ionicons name="cloud-upload-outline" size={20} color="#ff8c00" />
-              <Text style={styles.btnOutlineText}>Upload Photo</Text>
+            <TouchableOpacity
+              style={task.photosSubmitted >= task.photosRequired ? styles.btnSuccess : styles.btnOutline}
+              onPress={handleCompleteTask}
+              disabled={task.photosSubmitted < task.photosRequired}
+            >
+              <Ionicons name="checkmark-circle" size={20} color={task.photosSubmitted >= task.photosRequired ? 'white' : '#ff8c00'} />
+              <Text style={task.photosSubmitted >= task.photosRequired ? styles.btnText : styles.btnOutlineText}>
+                {task.photosSubmitted >= task.photosRequired ? 'Complete Task' : `Need ${task.photosRequired - task.photosSubmitted} more photo(s)`}
+              </Text>
             </TouchableOpacity>
           </>
-        )}
-
-        {taskStatus === 'ready_to_submit' && (
-          <TouchableOpacity style={styles.btnSuccess} onPress={handleCompleteTask}>
-            <Ionicons name="checkmark-circle" size={20} color="white" />
-            <Text style={styles.btnText}>Complete Task</Text>
-          </TouchableOpacity>
         )}
       </View>
 
       {/* ── Verification Modal ── */}
-      <Modal visible={showVerificationModal} transparent animationType="fade">
+      <Modal
+        visible={showVerificationModal}
+        transparent
+        animationType="fade"
+        onRequestClose={closeModal}
+      >
         <View style={styles.modalOverlay}>
           <View style={styles.modalCard}>
-
-            <View style={styles.cardRow}>
-              <Text style={styles.modalTitle}>Task Verification</Text>
-              <TouchableOpacity onPress={closeModal}>
-                <Ionicons name="close" size={20} color="white" />
-              </TouchableOpacity>
-            </View>
+            <Text style={styles.modalTitle}>Identity Verification</Text>
 
             {(verificationStep === 'initial' || verificationStep === 'biometric') && (
               <View style={styles.modalBody}>
                 <Text style={styles.modalText}>Verify your identity to start this task.</Text>
 
+                {/* Face ID / Fingerprint toggle */}
                 <View style={styles.methodRow}>
                   <TouchableOpacity
                     style={[styles.methodBtn, selectedMethod === 'face' && styles.methodBtnActive]}
@@ -314,6 +302,7 @@ export default function TicketDetailScreen() {
                   </TouchableOpacity>
                 </View>
 
+                {/* Scan button */}
                 <TouchableOpacity
                   style={[
                     styles.scanButton,
@@ -337,19 +326,23 @@ export default function TicketDetailScreen() {
                 {scanState === 'idle'     && <Text style={styles.hintText}>{selectedMethod === 'face' ? 'Tap to scan your face' : 'Tap to scan fingerprint'}</Text>}
                 {scanState === 'scanning' && <Text style={styles.hintText}>Scanning…</Text>}
 
+                {/* ── Failed state: retry + PIN fallback ──────────────────────
+                    "Use PIN instead" only appears after a scan fails — it is a
+                    fallback, not a first option. This matches the login biometric
+                    screen behaviour and prevents contractors bypassing biometrics. */}
                 {scanState === 'failed' && (
                   <>
                     <Text style={styles.errorText}>Scan failed — please try again.</Text>
                     <TouchableOpacity style={styles.btnPrimary} onPress={() => setScanState('idle')}>
                       <Text style={styles.btnText}>Retry</Text>
                     </TouchableOpacity>
+                    <TouchableOpacity style={styles.pinLink} onPress={() => setVerificationStep('pin')}>
+                      <Ionicons name="keypad-outline" size={16} color="#ff8c00" />
+                      <Text style={styles.pinLinkText}>Use PIN instead</Text>
+                    </TouchableOpacity>
                   </>
                 )}
 
-                <TouchableOpacity style={styles.pinLink} onPress={() => setVerificationStep('pin')}>
-                  <Ionicons name="keypad-outline" size={16} color="#ff8c00" />
-                  <Text style={styles.pinLinkText}>Use PIN instead</Text>
-                </TouchableOpacity>
               </View>
             )}
 
@@ -424,6 +417,24 @@ const CARD_BG = 'rgba(255,255,255,0.1)';
 const BORDER  = 'rgba(255,255,255,0.15)';
 
 const styles = StyleSheet.create({
+  backHeader: {
+    width: '90%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    marginTop: 16,
+    marginBottom: 16,
+  },
+  backBtn: {
+    width: 40, height: 40,
+    borderRadius: 8,
+    backgroundColor: CARD_BG,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  backHeaderText: { flex: 1 },
+  backTitle: { fontSize: 17, fontFamily: 'poppins-bold', color: 'white' },
+  backSubtitle: { fontSize: 11, color: '#9ca3af' },
 
   section: { width: '90%', marginBottom: 12 },
   taskTitle: { fontSize: 20, fontFamily: 'poppins-bold', color: 'white', marginBottom: 8 },
@@ -572,28 +583,4 @@ const styles = StyleSheet.create({
   hintText:    { fontSize: 12, color: '#9ca3af', textAlign: 'center' },
   pinLink:     { flexDirection: 'row', alignItems: 'center', gap: 6, alignSelf: 'center' },
   pinLinkText: { fontSize: 13, fontFamily: 'poppins-bold', color: '#ff8c00', textDecorationLine: 'underline' },
-
-  taskDetail: { fontSize: 11, color: '#9ca3af', marginTop: 2 },
-
-  assignRow: {
-    width: '90%',
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    gap: 8,
-    marginBottom: 8,
-  },
-  acceptBtn: {
-    backgroundColor: '#ff8c00',
-    borderRadius: 8, paddingVertical: 8,
-    paddingHorizontal: 14,
-    flexDirection: 'row', alignItems: 'center',
-    justifyContent: 'center', gap: 6,
-  },
-  declineBtn: {
-    backgroundColor: '#dc2626',
-    borderRadius: 8, paddingVertical: 8,
-    paddingHorizontal: 14,
-    flexDirection: 'row', alignItems: 'center',
-    justifyContent: 'center', gap: 6,
-  },
 });


### PR DESCRIPTION
Overview
This PR covers all updates to the authentication flow, profile screens, and MainFrame integration for the contractor mobile app. All screens under my ownership have been migrated to MainFrame and FieldForceHeader.tsx has been removed entirely since it is no longer needed.

Auth Flow Changes
There was a critical bug where login() was being called in LoginScreen before biometrics ran. If App.tsx gates on isAuthenticated to switch navigation stacks, this caused BiometricCheck to unmount before the user ever saw it, which effectively bypassed biometrics entirely.

To fix this, LoginScreen now passes pendingToken and pendingUser as navigation params to BiometricCheck instead of committing the session immediately. BiometricCheck is responsible for calling login() only after a successful scan, so the user is never considered authenticated until their identity has actually been verified.

SplashScreen
Added a token check on mount using AuthContext so the app can determine whether a valid session already exists. If a valid unexpired token is found, the user is routed directly to Home and skips the login flow entirely. If the token is missing or expired, they are sent to Login as normal. The screen now uses replace() instead of navigate() so it is removed from the navigation stack completely and cannot re-fire later in the session.

LoginScreen
Removed the duplicate Field Force title from the center of the screen since the MainFrame header already displays it at the top
Contractor Portal is now the main headline with larger bold styling so it is clear what this login page is for
Orange placeholder text inside the input fields following Aldo's polish commit
Login button turns amber when both fields are filled and the form is ready to submit, and grays out when not
BiometricScreen
Receives pendingToken and pendingUser as navigation params from LoginScreen
Loads the user's saved biometric preference from AsyncStorage on mount so the correct method is pre-selected
PIN option is only shown after a scan fails, not presented upfront as a first option
PasswordResetScreen
Fully migrated from SafeAreaView and FieldForceHeader to MainFrame
Placeholder text removed from all three input fields since the labels above them are sufficient
AsyncStorage biometric preference is loaded on mount so when the user reaches step 2, it opens with their saved default already selected
Redundant switch method link removed from the bottom of step 2 since the toggle buttons in the middle of the screen already handle method switching
LicenseScreen
Fully migrated to MainFrame
License status is now derived from the expiration date at runtime rather than trusting a hardcoded string from the backend
A 30 day expiring soon warning window displays an amber banner when the license is close to expiring
A red banner is shown when the license is expired, including how many days ago it expired
A dev toggle button is included at the bottom to demo both the active and expired states without needing to change any code
ProfileScreen
Task History menu row added that navigates to the new TaskHistoryScreen
Settings modal updated with biometric preference selection and a light/dark mode toggle, both persisted to AsyncStorage
useTheme() integrated for light and dark mode color support
TaskHistoryScreen (New Screen)
This is a new screen that gives contractors a full view of their task history. It is split into two sections, completed tasks and incomplete tasks, so they can reference both for their own records or in case a vendor follows up on something. A summary strip at the top shows the totals at a glance and each card is expandable to show the ticket reference number, location, and in the case of incomplete tasks, the reason it was not finished.

TicketDetailScreen
Biometric preference loaded from AsyncStorage on mount so the verification modal opens with the user's saved default
PIN link moved inside the failed state only, matching the same behaviour as the login biometric screen
MainFrame
SubHeader added as a named export so all screens can import it from one place rather than a separate file
FieldForceHeader.tsx has been deleted as it is no longer referenced anywhere in the codebase
ThemeContext (New File)
New context that provides dark and light color palettes across the whole app. It reads the user's saved appearance preference from AsyncStorage on startup so the correct theme is applied before the first render.

theme.ts
darkColors and lightColors palettes added as separate exports
The original static colors export is preserved as a fallback for any screens not yet migrated to useTheme
Testing Notes
DEV_MODE is currently set to true on BiometricScreen and LoginScreen to allow testing without a live backend connection. This should be set to false before any production build. The biometric preference can be changed in Profile, then Settings, and the selection will carry through to every screen in the app that involves biometric verification.