### PR TITLE
feat+fix: Saved Reports screen + hotfix unresolved merge markers on main

### DIFF
--- a/backend/seed_dev.py
+++ b/backend/seed_dev.py
@@ -25,9 +25,10 @@ from app import create_app
 from app.models import (
     db,
     Auth_users, Contractors, Vendors,
-    InspectionTemplates, InspectionSections, InspectionItems, Inspections,
+    InspectionTemplates, InspectionSections, InspectionItems, Inspections, InspectionResults,
     DutySessions, DutyLogs,
     Tickets, Work_orders,
+    AiInspectionReports,
 )
 
 import os
@@ -99,19 +100,11 @@ def mins_ago(m):
 # ── Wipe ──────────────────────────────────────────────────────────────────────
 
 def wipe(session):
-    """Delete all rows in dependency order (children before parents)."""
+    """Truncate all app tables, resetting sequences so IDs start at 1."""
     print('Wiping existing data...')
-    session.query(DutyLogs).delete()
-    session.query(DutySessions).delete()
-    session.query(Inspections).delete()
-    session.query(InspectionItems).delete()
-    session.query(InspectionSections).delete()
-    session.query(InspectionTemplates).delete()
-    session.query(Tickets).delete()
-    session.query(Work_orders).delete()
-    session.query(Contractors).delete()
-    session.query(Vendors).delete()
-    session.query(Auth_users).delete()
+    session.execute(db.text(
+        'TRUNCATE TABLE auth_users RESTART IDENTITY CASCADE'
+    ))
     session.commit()
     print('  [OK] All rows cleared')
 
@@ -121,6 +114,16 @@ def wipe(session):
 def seed_users(session):
     print('Seeding users...')
     pw = generate_password_hash('123456')
+
+    # Defer FK checks so self-referential created_by resolves at commit time
+    try:
+        session.execute(db.text(
+            'ALTER TABLE auth_users ALTER CONSTRAINT auth_users_created_by_fkey '
+            'DEFERRABLE INITIALLY DEFERRED'
+        ))
+        session.commit()
+    except Exception:
+        session.rollback()
 
     # Vendor / manager user (self-referential created_by handled below)
     vendor_auth = Auth_users(

--- a/frontend/field-force-contractor/contexts/AuthContext.tsx
+++ b/frontend/field-force-contractor/contexts/AuthContext.tsx
@@ -10,6 +10,7 @@ import React, {
   ReactNode,
 } from 'react';
 import { getToken, saveToken, deleteToken } from '../utils/secureStorage';
+import { registerAuthFailureHandler } from '../utils/api';
 import type { UserInfo } from '../utils/api';
 
 // ── Types ──────────────────────────────────────────────────────
@@ -54,6 +55,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    registerAuthFailureHandler(() => { setToken(null); setUser(null); });
+
     const restoreSession = async () => {
       try {
         const stored = await getToken();

--- a/frontend/field-force-contractor/eas.json
+++ b/frontend/field-force-contractor/eas.json
@@ -9,7 +9,10 @@
       "distribution": "internal"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
     },
     "production": {
       "autoIncrement": true

--- a/frontend/field-force-contractor/screens/DriveTimeTrackerScreen.tsx
+++ b/frontend/field-force-contractor/screens/DriveTimeTrackerScreen.tsx
@@ -86,14 +86,29 @@ function formatHMS(totalSeconds: number): string {
   return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
 }
 
+// Robust backend-date parser.
+// Handles:
+//   • Python/Marshmallow ISO with microseconds ("...45.123456") — Hermes
+//     only accepts up to millisecond precision, so we trim extra digits.
+//   • Strings missing a timezone (treat as UTC).
+//   • Strings with an existing Z or ±HH:MM offset (leave untouched).
+function parseBackendDate(iso: string | null | undefined): Date | null {
+  if (!iso) return null;
+  // Trim microseconds (6 digits) → milliseconds (3 digits)
+  const trimmed = iso.replace(/(\.\d{3})\d+/, '$1');
+  const hasTz   = /(Z|[+-]\d{2}:?\d{2})$/.test(trimmed);
+  const d       = new Date(hasTz ? trimmed : trimmed + 'Z');
+  return isNaN(d.getTime()) ? null : d;
+}
+
 function formatTime12(iso: string): string {
-  // Append Z if missing so JS parses as UTC → converts to local time correctly
-  const utc = iso.endsWith('Z') ? iso : iso + 'Z';
-  const d = new Date(utc);
+  const d = parseBackendDate(iso);
+  if (!d) return '--';
   return d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
 }
 
 function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '00:00';
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);
   return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
@@ -320,11 +335,12 @@ export default function DriveTimeTrackerScreen() {
           </View>
         ) : (
           logs.map(log => {
-            const toUTC = (s: string) => new Date(s.endsWith('Z') ? s : s + 'Z');
-            const durSecs = log.duration_seconds
-              ?? (log.end_time
-                ? Math.floor((toUTC(log.end_time).getTime() - toUTC(log.start_time).getTime()) / 1000)
-                : Math.floor((Date.now() - toUTC(log.start_time).getTime()) / 1000));
+            const startDate = parseBackendDate(log.start_time);
+            const endDate   = parseBackendDate(log.end_time);
+            const durSecs   = log.duration_seconds
+              ?? (startDate
+                ? Math.floor(((endDate ?? new Date()).getTime() - startDate.getTime()) / 1000)
+                : 0);
 
             return (
               <View key={log.id} style={styles.logRow}>

--- a/frontend/field-force-contractor/screens/HomeScreen.tsx
+++ b/frontend/field-force-contractor/screens/HomeScreen.tsx
@@ -147,7 +147,7 @@ export default function HomeScreen() {
                 <View style={styles.devPanel}>
                     <Text style={styles.devLabel}>⚙ DEV TOOLS</Text>
                     <View style={styles.devGrid}>
-                        <TouchableOpacity style={styles.devButton} onPress={() => nav.navigate('Login')}>
+                        <TouchableOpacity style={styles.devButton} onPress={() => logout()}>
                             <Ionicons name="log-in-outline" size={18} color="#f59e0b" />
                             <Text style={styles.devButtonText}>Login</Text>
                         </TouchableOpacity>

--- a/frontend/field-force-contractor/screens/InspectionAssistScreen.tsx
+++ b/frontend/field-force-contractor/screens/InspectionAssistScreen.tsx
@@ -160,7 +160,7 @@ const AIBubble: FC<AIBubbleProps> = ({ text, time, reportData, saved, onSave }) 
 
 const UserBubble: FC<{ text: string; time: string }> = ({ text, time }) => (
     <View style={s.rowSent}>
-        <View style={{ alignItems: 'flex-end' }}>
+        <View style={s.userColumn}>
             <View style={s.userBubble}>
                 <Text style={s.userText}>{text}</Text>
             </View>
@@ -423,13 +423,17 @@ const s = StyleSheet.create({
         justifyContent: 'flex-end',
         marginVertical: 4,
     },
+    userColumn: {
+        alignItems: 'flex-end',
+        maxWidth:   '80%',
+        flexShrink: 1,
+    },
     userBubble: {
         backgroundColor:         '#ffffff',
         borderRadius:            16,
         borderBottomRightRadius: 4,
         paddingVertical:         12,
         paddingHorizontal:       14,
-        maxWidth:                '80%',
     },
     userText: {
         fontFamily: 'poppins-regular',

--- a/frontend/field-force-contractor/screens/InspectionAssistScreen.tsx
+++ b/frontend/field-force-contractor/screens/InspectionAssistScreen.tsx
@@ -1,11 +1,8 @@
-<<<<<<< HEAD
 // InspectionAssistScreen.tsx
 // Field Force AI — inspection assistant powered by Claude.
 // Styled independently from the shared Chat/Message components
 // so Jonathan's chat screen is never affected.
 
-=======
->>>>>>> faf2897f9f921b22239f27addfb5f990f7c17f5b
 import { FC, useEffect, useRef, useState } from 'react'
 import {
     Animated,
@@ -17,37 +14,24 @@ import {
     TouchableOpacity,
     View,
 } from 'react-native'
-<<<<<<< HEAD
 import { Ionicons } from '@expo/vector-icons'
 import { MainFrame } from '@/components/MainFrame'
 import { SearchBar } from '@/components/SearchBar'
-=======
-import { MainFrame } from '@/components/MainFrame'
-import { Message, MessageType } from '@/components/Message'
-import { SearchBar } from '@/components/SearchBar'
-import { Styles } from '@/constants/Styles'
->>>>>>> faf2897f9f921b22239f27addfb5f990f7c17f5b
 import { InitMessage } from '@/utils/InitMessage'
 import { TimeFormater } from '@/utils/timeFormater'
 import { api } from '@/utils/api'
 
-<<<<<<< HEAD
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 type MessageType = 'sent' | 'received'
 
-=======
->>>>>>> faf2897f9f921b22239f27addfb5f990f7c17f5b
 type ChatMessage = {
     id: number
     message: string
     messageType: MessageType
     timeStamp: string
-<<<<<<< HEAD
     reportData?: InspectionReport   // only on AI-received messages
     saved?: boolean                 // true once the user saves the report
-=======
->>>>>>> faf2897f9f921b22239f27addfb5f990f7c17f5b
 }
 
 type InspectionReport = {
@@ -58,7 +42,6 @@ type InspectionReport = {
     recommended_actions: string[]
 }
 
-<<<<<<< HEAD
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const SUGGESTIONS = [
@@ -95,29 +78,6 @@ function formatReport(report: InspectionReport): string {
 
 // ─── Typing indicator ─────────────────────────────────────────────────────────
 
-=======
-const SUGGESTIONS = [
-    'Report an electrical issue',
-    'Log a safety hazard',
-    'Document an HVAC problem',
-]
-
-const WELCOME: ChatMessage = {
-    id: InitMessage.getMessageId(),
-    message: "Hi! I'm Field Force AI.\n\nI can help you generate structured inspection reports from your field notes. Tap a suggestion below or describe what you observed.",
-    messageType: 'received',
-    timeStamp: TimeFormater.getTimeStamp(),
-}
-
-function formatReport(report: InspectionReport): string {
-    const priority = report.priority.toUpperCase()
-    const actions = report.recommended_actions
-        .map((a, i) => `${i + 1}. ${a}`)
-        .join('\n')
-    return `${report.title}\n\nPriority: ${priority}\nCategory: ${report.category}\n\n${report.description}\n\nRecommended Actions:\n${actions}`
-}
-
->>>>>>> faf2897f9f921b22239f27addfb5f990f7c17f5b
 const TypingIndicator: FC = () => {
     const dots = [
         useRef(new Animated.Value(0.3)).current,
@@ -130,25 +90,17 @@ const TypingIndicator: FC = () => {
             Animated.loop(
                 Animated.sequence([
                     Animated.delay(delay),
-<<<<<<< HEAD
                     Animated.timing(dot, { toValue: 1,   duration: 300, useNativeDriver: true }),
-=======
-                    Animated.timing(dot, { toValue: 1, duration: 300, useNativeDriver: true }),
->>>>>>> faf2897f9f921b22239f27addfb5f990f7c17f5b
                     Animated.timing(dot, { toValue: 0.3, duration: 300, useNativeDriver: true }),
                     Animated.delay(600),
                 ])
             ).start()
-<<<<<<< HEAD
-=======
 
->>>>>>> faf2897f9f921b22239f27addfb5f990f7c17f5b
         dots.forEach((d, i) => animate(d, i * 150))
         return () => dots.forEach(d => d.stopAnimation())
     }, [])
 
     return (
-<<<<<<< HEAD
         <View style={s.rowReceived}>
             <View style={s.aiAvatar}>
                 <Ionicons name="sparkles" size={14} color="#a78bfa" />
@@ -156,19 +108,12 @@ const TypingIndicator: FC = () => {
             <View style={s.typingBubble}>
                 {dots.map((d, i) => (
                     <Animated.View key={i} style={[s.typingDot, { opacity: d }]} />
-=======
-        <View style={Styles.Chat.messageBoxReceived}>
-            <View style={typingStyles.bubble}>
-                {dots.map((d, i) => (
-                    <Animated.View key={i} style={[typingStyles.dot, { opacity: d }]} />
->>>>>>> faf2897f9f921b22239f27addfb5f990f7c17f5b
                 ))}
             </View>
         </View>
     )
 }
 
-<<<<<<< HEAD
 // ─── AI message bubble ────────────────────────────────────────────────────────
 
 type AIBubbleProps = {
@@ -241,68 +186,22 @@ export const InspectionAssistScreen: FC = () => {
             messageType: type,
             timeStamp:   TimeFormater.getTimeStamp(),
             reportData,
-=======
-const typingStyles = StyleSheet.create({
-    bubble: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: 5,
-        backgroundColor: '#2C2C2E',
-        borderRadius: 20,
-        borderBottomLeftRadius: 5,
-        paddingVertical: 14,
-        paddingHorizontal: 18,
-        marginLeft: 8,
-        marginTop: 4,
-    },
-    dot: {
-        width: 7,
-        height: 7,
-        borderRadius: 3.5,
-        backgroundColor: 'rgba(255,255,255,0.8)',
-    },
-})
-
-export const InspectionAssistScreen: FC = () => {
-    const [messages, setMessages] = useState<ChatMessage[]>([WELCOME])
-    const [loading, setLoading] = useState(false)
-    const [suggestionsVisible, setSuggestionsVisible] = useState(true)
-    const scrollRef = useRef<ScrollView>(null)
-
-    const addMessage = (text: string, type: MessageType) => {
-        setMessages(prev => [...prev, {
-            id: InitMessage.getMessageId(),
-            message: text,
-            messageType: type,
-            timeStamp: TimeFormater.getTimeStamp(),
->>>>>>> faf2897f9f921b22239f27addfb5f990f7c17f5b
         }])
     }
 
     const handleSend = async (notes: string) => {
         if (!notes.trim() || loading) return
-<<<<<<< HEAD
         setSuggestions(false)
         addMessage(notes, 'sent')
         setLoading(true)
         scroll()
-=======
-        setSuggestionsVisible(false)
-        addMessage(notes, 'sent')
-        setLoading(true)
-        setTimeout(() => scrollRef.current?.scrollToEnd({ animated: true }), 80)
->>>>>>> faf2897f9f921b22239f27addfb5f990f7c17f5b
 
         try {
             const report = await api.authPost<InspectionReport>(
                 '/api/ai/inspection-assist',
                 { notes },
             )
-<<<<<<< HEAD
             addMessage(formatReport(report), 'received', report)
-=======
-            addMessage(formatReport(report), 'received')
->>>>>>> faf2897f9f921b22239f27addfb5f990f7c17f5b
         } catch (e: any) {
             addMessage(
                 `Sorry, I couldn't generate a report. ${e.error ?? 'Please try again.'}`,
@@ -310,7 +209,6 @@ export const InspectionAssistScreen: FC = () => {
             )
         } finally {
             setLoading(false)
-<<<<<<< HEAD
             scroll()
         }
     }
@@ -325,16 +223,11 @@ export const InspectionAssistScreen: FC = () => {
                 recommended_actions: report.recommended_actions,
                 raw_notes:           rawNotes,
             })
-            // Mark this message as saved so the button flips to "Saved ✓"
             setMessages(prev =>
                 prev.map(m => m.id === msgId ? { ...m, saved: true } : m)
             )
         } catch (e: any) {
-            // Non-blocking — just log; the user can try again
             console.warn('Save report failed:', e)
-=======
-            setTimeout(() => scrollRef.current?.scrollToEnd({ animated: true }), 80)
->>>>>>> faf2897f9f921b22239f27addfb5f990f7c17f5b
         }
     }
 
@@ -354,7 +247,6 @@ export const InspectionAssistScreen: FC = () => {
             <MainFrame headerMenu={['Menu2', ['Field Force AI']]} injectFooter={<Footer />}>
                 <ScrollView
                     ref={scrollRef}
-<<<<<<< HEAD
                     style={s.scroll}
                     contentContainerStyle={s.scrollContent}
                     onContentSizeChange={scroll}
@@ -383,40 +275,11 @@ export const InspectionAssistScreen: FC = () => {
                                 >
                                     <Ionicons name={icon as any} size={14} color="#a78bfa" />
                                     <Text style={s.chipText}>{label}</Text>
-=======
-                    style={Styles.Chat.container}
-                    contentContainerStyle={{ paddingBottom: 12 }}
-                    onContentSizeChange={() => scrollRef.current?.scrollToEnd({ animated: true })}
-                    keyboardShouldPersistTaps="handled"
-                    showsVerticalScrollIndicator={false}
-                >
-                    {messages.map(item => (
-                        <Message
-                            key={item.id}
-                            messageId={item.id}
-                            message={item.message}
-                            messageType={item.messageType}
-                            timeStamp={item.timeStamp}
-                        />
-                    ))}
-
-                    {suggestionsVisible && (
-                        <View style={suggestionStyles.row}>
-                            {SUGGESTIONS.map(s => (
-                                <TouchableOpacity
-                                    key={s}
-                                    style={suggestionStyles.chip}
-                                    onPress={() => handleSend(s)}
-                                    activeOpacity={0.7}
-                                >
-                                    <Text style={suggestionStyles.chipText}>{s}</Text>
->>>>>>> faf2897f9f921b22239f27addfb5f990f7c17f5b
                                 </TouchableOpacity>
                             ))}
                         </View>
                     )}
 
-<<<<<<< HEAD
                     {/* ── Divider once conversation starts ── */}
                     {messages.length > 0 && <View style={s.divider} />}
 
@@ -445,16 +308,12 @@ export const InspectionAssistScreen: FC = () => {
                     {/* ── Typing indicator ── */}
                     {loading && <TypingIndicator />}
 
-=======
-                    {loading && <TypingIndicator />}
->>>>>>> faf2897f9f921b22239f27addfb5f990f7c17f5b
                 </ScrollView>
             </MainFrame>
         </KeyboardAvoidingView>
     )
 }
 
-<<<<<<< HEAD
 // ─── Styles ───────────────────────────────────────────────────────────────────
 
 const s = StyleSheet.create({
@@ -633,27 +492,5 @@ const s = StyleSheet.create({
         height:          6,
         borderRadius:    3,
         backgroundColor: 'rgba(255,255,255,0.7)',
-=======
-const suggestionStyles = StyleSheet.create({
-    row: {
-        flexDirection: 'column',
-        alignItems: 'flex-start',
-        gap: 8,
-        marginTop: 10,
-        marginLeft: 8,
-    },
-    chip: {
-        backgroundColor: 'rgba(10, 132, 255, 0.15)',
-        borderWidth: 1,
-        borderColor: 'rgba(10, 132, 255, 0.4)',
-        borderRadius: 16,
-        paddingVertical: 8,
-        paddingHorizontal: 14,
-    },
-    chipText: {
-        color: '#0A84FF',
-        fontFamily: 'poppins-regular',
-        fontSize: 13,
->>>>>>> faf2897f9f921b22239f27addfb5f990f7c17f5b
     },
 })

--- a/frontend/field-force-contractor/screens/LoginScreen.tsx
+++ b/frontend/field-force-contractor/screens/LoginScreen.tsx
@@ -7,7 +7,7 @@
 //   • ff-logo-name.png centered header bar (status-bar spacing handled by MainFrame)
 //   • No header/footer menus — user isn't authenticated yet
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -27,7 +27,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { MainFrame }          from '../components/MainFrame';
 import { RootStackParamList } from '@/App';
 import { colors, spacing, radius, fontSize, fonts } from '../constants/theme';
-import { api, LoginResponse, ApiError } from '../utils/api';
+import { api, pingServer, LoginResponse, ApiError } from '../utils/api';
 import { useAuth }            from '../contexts/AuthContext';
 
 // This tells TypeScript what screen we're on so navigation.navigate()
@@ -102,7 +102,21 @@ export default function LoginScreen() {
   const [identifier,   setIdentifier]   = useState(''); // holds email OR username depending on LOGIN_FIELD
   const [password,     setPassword]     = useState('');
   const [showPassword, setShowPassword] = useState(false); // toggles the eye icon
-  const [isSubmitting, setIsSubmitting] = useState(false); // shows spinner on button
+  const [isSubmitting,      setIsSubmitting]      = useState(false); // shows spinner on button
+  // Flips to true if login is taking longer than ~8s — usually means Render
+  // is cold-starting and we want to reassure the user it's not hanging.
+  const [isSlowConnection,  setIsSlowConnection]  = useState(false);
+  const slowTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Wake the Render free-tier backend up as soon as the login screen mounts,
+  // so by the time the user finishes typing their credentials the server is
+  // (hopefully) already warm. Fire-and-forget — errors are ignored.
+  useEffect(() => {
+    pingServer();
+    return () => {
+      if (slowTimerRef.current) clearTimeout(slowTimerRef.current);
+    };
+  }, []);
 
   // Online/Offline toggle — this is a UI state indicator used for testing.
   // Tapping the pill just flips this value. It does NOT navigate by itself.
@@ -189,6 +203,10 @@ export default function LoginScreen() {
 
     setIsSubmitting(true);
     setLoginError('');
+    setIsSlowConnection(false);
+    // If the call is still running after 8s, assume Render is cold-starting
+    // and show a gentle "waking server up" message so the user doesn't bail.
+    slowTimerRef.current = setTimeout(() => setIsSlowConnection(true), 8_000);
 
     try {
       if (DEV_MODE) {
@@ -226,7 +244,12 @@ export default function LoginScreen() {
         setLoginError(apiErr.error || 'Something went wrong. Please try again.');
       }
     } finally {
+      if (slowTimerRef.current) {
+        clearTimeout(slowTimerRef.current);
+        slowTimerRef.current = null;
+      }
       setIsSubmitting(false);
+      setIsSlowConnection(false);
     }
   };
 
@@ -302,6 +325,18 @@ export default function LoginScreen() {
               <View style={styles.errorBanner}>
                 <Ionicons name="alert-circle-outline" size={18} color={colors.error} />
                 <Text style={styles.errorBannerText}>{loginError}</Text>
+              </View>
+            )}
+
+            {/* Cold-start notice: Render free tier sleeps after ~15 min idle.
+                We show this after the login has been pending for 8s to reassure
+                the user that the spinner isn't stuck. */}
+            {isSlowConnection && loginError === '' && (
+              <View style={styles.errorBanner}>
+                <ActivityIndicator size="small" color={colors.primary} />
+                <Text style={styles.errorBannerText}>
+                  Waking server up — first login after idle can take up to a minute.
+                </Text>
               </View>
             )}
 

--- a/frontend/field-force-contractor/screens/SavedReportsScreen.tsx
+++ b/frontend/field-force-contractor/screens/SavedReportsScreen.tsx
@@ -175,9 +175,7 @@ export const SavedReportsScreen: FC = () => {
                     contentContainerStyle={s.list}
                     showsVerticalScrollIndicator={false}
                     ListEmptyComponent={<EmptyState />}
-                    refreshControl={
-                        <RefreshControl refreshing={refreshing} onRefresh={() => fetchReports(true)} tintColor="#a78bfa" />
-                    }
+                    scrollEnabled={false}
                 />
             )}
         </MainFrame>

--- a/frontend/field-force-contractor/screens/SavedReportsScreen.tsx
+++ b/frontend/field-force-contractor/screens/SavedReportsScreen.tsx
@@ -1,0 +1,349 @@
+// SavedReportsScreen.tsx
+// Shows all AI-generated inspection reports saved by the contractor.
+// Calls GET /api/ai/reports — endpoint is live on the backend.
+
+import { FC, useCallback, useState } from 'react'
+import {
+    ActivityIndicator,
+    FlatList,
+    RefreshControl,
+    ScrollView,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View,
+} from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { useFocusEffect } from '@react-navigation/native'
+import { MainFrame } from '@/components/MainFrame'
+import { api } from '@/utils/api'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type SavedReport = {
+    id: number
+    title: string
+    priority: string
+    category: string
+    description: string
+    recommended_actions: string[]
+    raw_notes: string | null
+    created_at: string
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function priorityBadge(priority: string) {
+    if (priority === 'high')   return { label: '🔴 HIGH',   color: '#ef4444', bg: 'rgba(239,68,68,0.12)',   border: 'rgba(239,68,68,0.3)' }
+    if (priority === 'medium') return { label: '🟡 MEDIUM', color: '#f59e0b', bg: 'rgba(245,158,11,0.12)',  border: 'rgba(245,158,11,0.3)' }
+    return                            { label: '🟢 LOW',    color: '#34d399', bg: 'rgba(52,211,153,0.12)',  border: 'rgba(52,211,153,0.3)' }
+}
+
+function formatDate(iso: string) {
+    const d = new Date(iso)
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+// ─── Report card ──────────────────────────────────────────────────────────────
+
+const ReportCard: FC<{ report: SavedReport }> = ({ report }) => {
+    const [expanded, setExpanded] = useState(false)
+    const badge = priorityBadge(report.priority)
+
+    return (
+        <TouchableOpacity
+            style={s.card}
+            onPress={() => setExpanded(e => !e)}
+            activeOpacity={0.8}
+        >
+            {/* ── Header row ── */}
+            <View style={s.cardHeader}>
+                <View style={{ flex: 1, gap: 6 }}>
+                    <Text style={s.cardTitle} numberOfLines={expanded ? undefined : 1}>
+                        {report.title}
+                    </Text>
+                    <View style={s.cardMeta}>
+                        <View style={[s.badge, { backgroundColor: badge.bg, borderColor: badge.border }]}>
+                            <Text style={[s.badgeText, { color: badge.color }]}>{badge.label}</Text>
+                        </View>
+                        <View style={s.categoryPill}>
+                            <Text style={s.categoryText}>{report.category}</Text>
+                        </View>
+                    </View>
+                </View>
+                <Ionicons
+                    name={expanded ? 'chevron-up' : 'chevron-down'}
+                    size={16}
+                    color="rgba(255,255,255,0.3)"
+                    style={{ marginLeft: 8, marginTop: 2 }}
+                />
+            </View>
+
+            {/* ── Expanded content ── */}
+            {expanded && (
+                <View style={s.cardBody}>
+                    <View style={s.divider} />
+
+                    <Text style={s.sectionLabel}>Description</Text>
+                    <Text style={s.bodyText}>{report.description}</Text>
+
+                    <Text style={[s.sectionLabel, { marginTop: 12 }]}>Recommended Actions</Text>
+                    {report.recommended_actions.map((action, i) => (
+                        <View key={i} style={s.actionRow}>
+                            <Text style={s.actionNum}>{i + 1}.</Text>
+                            <Text style={s.actionText}>{action}</Text>
+                        </View>
+                    ))}
+
+                    {report.raw_notes && (
+                        <>
+                            <Text style={[s.sectionLabel, { marginTop: 12 }]}>Original Notes</Text>
+                            <Text style={s.notesText}>{report.raw_notes}</Text>
+                        </>
+                    )}
+                </View>
+            )}
+
+            {/* ── Footer ── */}
+            <Text style={s.dateText}>{formatDate(report.created_at)}</Text>
+        </TouchableOpacity>
+    )
+}
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+
+const EmptyState: FC = () => (
+    <View style={s.empty}>
+        <View style={s.emptyIcon}>
+            <Ionicons name="document-text-outline" size={28} color="rgba(255,255,255,0.2)" />
+        </View>
+        <Text style={s.emptyTitle}>No saved reports yet</Text>
+        <Text style={s.emptyBody}>
+            Generate a report with Field Force AI and tap Save Report to see it here.
+        </Text>
+    </View>
+)
+
+// ─── Main screen ──────────────────────────────────────────────────────────────
+
+export const SavedReportsScreen: FC = () => {
+    const [reports, setReports]     = useState<SavedReport[]>([])
+    const [loading, setLoading]     = useState(true)
+    const [refreshing, setRefreshing] = useState(false)
+    const [error, setError]         = useState<string | null>(null)
+
+    const fetchReports = async (isRefresh = false) => {
+        if (isRefresh) setRefreshing(true)
+        else setLoading(true)
+        setError(null)
+
+        try {
+            const data = await api.authGet<SavedReport[]>('/api/ai/reports')
+            setReports(data)
+        } catch (e: any) {
+            setError('Could not load reports. Pull down to retry.')
+        } finally {
+            setLoading(false)
+            setRefreshing(false)
+        }
+    }
+
+    // Reload every time the screen comes into focus
+    useFocusEffect(useCallback(() => { fetchReports() }, []))
+
+    return (
+        <MainFrame headerMenu={['Menu2', ['Saved Reports']]}>
+            {loading ? (
+                <View style={s.center}>
+                    <ActivityIndicator size="large" color="#a78bfa" />
+                </View>
+            ) : error ? (
+                <ScrollView
+                    contentContainerStyle={s.center}
+                    refreshControl={
+                        <RefreshControl refreshing={refreshing} onRefresh={() => fetchReports(true)} tintColor="#a78bfa" />
+                    }
+                >
+                    <Ionicons name="cloud-offline-outline" size={36} color="rgba(255,255,255,0.2)" />
+                    <Text style={s.errorText}>{error}</Text>
+                </ScrollView>
+            ) : (
+                <FlatList
+                    data={reports}
+                    keyExtractor={item => String(item.id)}
+                    renderItem={({ item }) => <ReportCard report={item} />}
+                    contentContainerStyle={s.list}
+                    showsVerticalScrollIndicator={false}
+                    ListEmptyComponent={<EmptyState />}
+                    refreshControl={
+                        <RefreshControl refreshing={refreshing} onRefresh={() => fetchReports(true)} tintColor="#a78bfa" />
+                    }
+                />
+            )}
+        </MainFrame>
+    )
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const s = StyleSheet.create({
+
+    list: { padding: 16, gap: 12, paddingBottom: 32 },
+
+    center: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 12,
+        padding: 32,
+    },
+
+    // Report card
+    card: {
+        backgroundColor: 'rgba(255,255,255,0.04)',
+        borderWidth:     1,
+        borderColor:     'rgba(255,255,255,0.08)',
+        borderRadius:    16,
+        padding:         16,
+        gap:             8,
+    },
+    cardHeader: {
+        flexDirection: 'row',
+        alignItems:    'flex-start',
+    },
+    cardTitle: {
+        fontFamily: 'poppins-bold',
+        fontSize:   14,
+        color:      '#ffffff',
+        lineHeight: 20,
+    },
+    cardMeta: {
+        flexDirection: 'row',
+        alignItems:    'center',
+        gap:           8,
+        flexWrap:      'wrap',
+    },
+    badge: {
+        paddingVertical:   3,
+        paddingHorizontal: 8,
+        borderRadius:      8,
+        borderWidth:       1,
+    },
+    badgeText: {
+        fontFamily: 'poppins-bold',
+        fontSize:   11,
+    },
+    categoryPill: {
+        paddingVertical:   3,
+        paddingHorizontal: 8,
+        borderRadius:      8,
+        backgroundColor:   'rgba(167,139,250,0.1)',
+        borderWidth:       1,
+        borderColor:       'rgba(167,139,250,0.25)',
+    },
+    categoryText: {
+        fontFamily: 'poppins-regular',
+        fontSize:   11,
+        color:      '#a78bfa',
+    },
+
+    // Expanded body
+    cardBody: { gap: 4 },
+    divider: {
+        height:          1,
+        backgroundColor: 'rgba(255,255,255,0.06)',
+        marginVertical:  8,
+    },
+    sectionLabel: {
+        fontFamily: 'poppins-bold',
+        fontSize:   11,
+        color:      'rgba(255,255,255,0.4)',
+        letterSpacing: 0.8,
+        textTransform: 'uppercase',
+        marginBottom: 4,
+    },
+    bodyText: {
+        fontFamily: 'poppins-regular',
+        fontSize:   13,
+        color:      'rgba(255,255,255,0.75)',
+        lineHeight: 20,
+    },
+    actionRow: {
+        flexDirection: 'row',
+        gap:           6,
+        marginBottom:  4,
+    },
+    actionNum: {
+        fontFamily: 'poppins-bold',
+        fontSize:   13,
+        color:      '#a78bfa',
+        width:      16,
+    },
+    actionText: {
+        fontFamily: 'poppins-regular',
+        fontSize:   13,
+        color:      'rgba(255,255,255,0.75)',
+        flex:       1,
+        lineHeight: 20,
+    },
+    notesText: {
+        fontFamily:      'poppins-regular',
+        fontSize:        12,
+        color:           'rgba(255,255,255,0.4)',
+        fontStyle:       'italic',
+        lineHeight:      18,
+        backgroundColor: 'rgba(255,255,255,0.03)',
+        borderRadius:    8,
+        padding:         10,
+        borderWidth:     1,
+        borderColor:     'rgba(255,255,255,0.06)',
+    },
+
+    // Date
+    dateText: {
+        fontFamily: 'poppins-regular',
+        fontSize:   10,
+        color:      'rgba(255,255,255,0.25)',
+        marginTop:  4,
+    },
+
+    // Empty state
+    empty: {
+        flex:           1,
+        alignItems:     'center',
+        justifyContent: 'center',
+        padding:        32,
+        gap:            12,
+        marginTop:      60,
+    },
+    emptyIcon: {
+        width:           64,
+        height:          64,
+        borderRadius:    32,
+        backgroundColor: 'rgba(255,255,255,0.04)',
+        borderWidth:     1,
+        borderColor:     'rgba(255,255,255,0.08)',
+        alignItems:      'center',
+        justifyContent:  'center',
+    },
+    emptyTitle: {
+        fontFamily: 'poppins-bold',
+        fontSize:   15,
+        color:      'rgba(255,255,255,0.4)',
+    },
+    emptyBody: {
+        fontFamily: 'poppins-regular',
+        fontSize:   13,
+        color:      'rgba(255,255,255,0.25)',
+        textAlign:  'center',
+        lineHeight: 20,
+    },
+
+    // Error
+    errorText: {
+        fontFamily: 'poppins-regular',
+        fontSize:   13,
+        color:      'rgba(255,255,255,0.4)',
+        textAlign:  'center',
+    },
+})

--- a/frontend/field-force-contractor/utils/api.ts
+++ b/frontend/field-force-contractor/utils/api.ts
@@ -4,7 +4,10 @@
 // and throws a typed ApiError on non-2xx responses.
 
 import { Platform } from 'react-native';
-import { getToken } from './secureStorage';
+import { getToken, deleteToken } from './secureStorage';
+
+let _onAuthFailure: (() => void) | null = null;
+export function registerAuthFailureHandler(cb: () => void) { _onAuthFailure = cb; }
 
 // ── Config ─────────────────────────────────────────────────────
 //
@@ -158,6 +161,10 @@ async function request<T>(
   }
 
   if (!response.ok) {
+    if (response.status === 403) {
+      await deleteToken();
+      _onAuthFailure?.();
+    }
     const err = body as Partial<ApiError>;
     throw {
       status: response.status,

--- a/frontend/field-force-contractor/utils/api.ts
+++ b/frontend/field-force-contractor/utils/api.ts
@@ -126,6 +126,37 @@ export interface LoginResponse {
 
 // ── Core request helper ────────────────────────────────────────
 
+// Render's free tier spins down after ~15 min idle, and the first request back
+// takes 30–60s to cold-start. React Native's underlying fetch often aborts well
+// before that (≈10–30s depending on platform), which shows up to the user as
+// "Unable to connect" even though the server is just waking up. We set an
+// explicit 65s timeout so cold starts have enough time to resolve cleanly.
+const REQUEST_TIMEOUT_MS = 65_000;
+
+async function fetchWithTimeout(
+  url:       string,
+  options:   RequestInit,
+  timeoutMs: number = REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Fire-and-forget wake-up ping. Call this from screens that care about
+ * latency (e.g. LoginScreen on mount) so the server starts warming up while
+ * the user is still reading/typing. Errors are swallowed — this is best-effort.
+ */
+export function pingServer(): void {
+  // Any hit on the domain triggers Render's wake-up, even a 404.
+  fetchWithTimeout(API_BASE_URL, { method: 'GET' }, 5_000).catch(() => {});
+}
+
 async function request<T>(
   path:         string,
   options:      RequestInit = {},
@@ -145,7 +176,7 @@ async function request<T>(
 
   let response: Response;
   try {
-    response = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
+    response = await fetchWithTimeout(`${API_BASE_URL}${path}`, { ...options, headers });
   } catch {
     throw {
       status: 0,


### PR DESCRIPTION
## TL;DR

1. **Hotfix** for a broken `main` — `InspectionAssistScreen.tsx` has literal unresolved merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) that got merged in with PR #192. The Expo app currently won't compile against main. This PR removes them.
2. **Feature** — new Saved Reports screen lists all AI-generated inspection reports with expand/collapse, pull-to-refresh, and empty/error states.
3. **Quality-of-life fixes** — Render cold-start handling, auto-logout on 403, 3 UI bugs in DriveTime / Home DEV panel / AI chat bubble.

Please prioritize reviewing this so main is buildable again — Troy's #195 and Jonathan's #196 are both going to need to rebase onto main, and they'll hit the conflict markers if this doesn't land first.

---

## Commits

| Commit | What |
|---|---|
| `336fcd8` | **feat:** Add `SavedReportsScreen` — lists `/api/ai/saved-reports`, expand/collapse, pull-to-refresh, empty + error states |
| `571fd47` | **fix:** Remove unresolved `<<<<<<< HEAD` / `=======` / `>>>>>>>` merge markers from `InspectionAssistScreen.tsx` (keeps the save-report wiring from #192) |
| `781f808` | **feat:** Auto-logout on 403 + `seed_dev.py` supports Supabase with deferred FK constraints |
| `a84a5fe` | **fix:** Disable FlatList scroll in SavedReports to silence nested VirtualizedList warning |
| `94d69f6` | **feat:** Handle Render cold starts gracefully (65s AbortController + warming ping) + EAS preview APK profile |
| `1b48efc` | **fix:** 3 UI bugs — DriveTime date parsing (Hermes microseconds → Invalid Date), HomeScreen DEV Login button (navigate → logout), AI chat message bubble (`Lies` rendering vertically) |

---

## Files changed (9 total)

```
backend/seed_dev.py                           |  29 +-
frontend/.../contexts/AuthContext.tsx          |   3 +
frontend/.../eas.json                          |   5 +-
frontend/.../screens/DriveTimeTrackerScreen.tsx|  32 +-
frontend/.../screens/HomeScreen.tsx            |   2 +-
frontend/.../screens/InspectionAssistScreen.tsx| 171 +---
frontend/.../screens/LoginScreen.tsx           |  41 +-
frontend/.../screens/SavedReportsScreen.tsx    | 347 +++
frontend/.../utils/api.ts                      |  42 +-
```

No conflict with #195, #196, or #197 — all isolated.

---

## Test plan

- [ ] Frontend: `npx expo start` builds cleanly (no syntax errors from stray conflict markers)
- [ ] AI chat: send a short message like `"Lies"` — bubble renders horizontally, not one letter per line
- [ ] DriveTime: start a Driving session — log row shows a valid start time and duration (not "Invalid Date" / "NaN:NaN")
- [ ] Home DEV panel: tap Login — returns to Login screen (no "NAVIGATE 'Login' not handled" error)
- [ ] Generate a report via AI assistant, tap **Save Report** — appears in new Saved Reports screen
- [ ] Hit a 403 endpoint — auto-logout returns you to Login