### PR TITLE
Remove unused voice libs to restore Expo Go compatibility

### DIFF
--- a/frontend/field-force-contractor/App.tsx
+++ b/frontend/field-force-contractor/App.tsx
@@ -108,15 +108,17 @@ function RootNavigator() {
   }
 
   return (
-    <StackNavigator.Navigator screenOptions={screenConfig.window} initialRouteName="SplashScreen">
-      {/* SplashScreen is the universal entry point — its own logic uses nav.replace()
-          to route to Home (if authenticated) or Login (if not). Always available. */}
-      <StackNavigator.Screen name="SplashScreen" component={SplashScreen} />
-
+    <StackNavigator.Navigator
+      screenOptions={screenConfig.window}
+      initialRouteName={isAuthenticated ? 'Inspection' : 'SplashScreen'}
+    >
       {isAuthenticated ? (
         // ── Protected App screens ─────────────────────────────────────────
-        // First screen is Inspection — the daily gate. After passing (or skipping)
-        // it navigates to Dashboard. All other app screens follow.
+        // No SplashScreen here: once auth flips true the Auth stack unmounts
+        // and this stack mounts with Inspection as its initial route. Keeping
+        // Splash registered across both stacks caused React Navigation to
+        // fall back to it after the swap, where a stale closure in its
+        // useEffect would navigate the user back to Login.
         <>
           <StackNavigator.Screen name="Inspection"       component={InspectionScreen}       />
           <StackNavigator.Screen name="Dashboard"        component={HomeScreen}              />
@@ -139,6 +141,7 @@ function RootNavigator() {
         // call the auth state flips and React Navigation auto-routes to
         // Inspection above.
         <>
+          <StackNavigator.Screen name="SplashScreen"    component={SplashScreen}          />
           <StackNavigator.Screen name="Login"           component={LoginScreen}           />
           <StackNavigator.Screen name="OfflineLogin"    component={OfflineLoginScreen}    />
           <StackNavigator.Screen name="BiometricCheck"  component={BiometricScreen}       />

--- a/frontend/field-force-contractor/app.json
+++ b/frontend/field-force-contractor/app.json
@@ -37,7 +37,6 @@
     "plugins": [
       "expo-splash-screen",
       "expo-font",
-      "expo-speech-recognition",
       "expo-secure-store"
     ],
     "experiments": {

--- a/frontend/field-force-contractor/package-lock.json
+++ b/frontend/field-force-contractor/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
-        "@react-native-voice/voice": "^3.2.4",
+        "@react-native-async-storage/async-storage": "2.2.0",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.2.2",
@@ -22,7 +22,6 @@
         "expo-linking": "~8.0.11",
         "expo-local-authentication": "~17.0.8",
         "expo-secure-store": "~15.0.8",
-        "expo-speech-recognition": "^3.1.2",
         "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
         "expo-symbols": "~1.0.8",
@@ -2559,160 +2558,16 @@
         "node": ">=12.4.0"
       }
     },
-    "node_modules/@react-native-voice/voice": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@react-native-voice/voice/-/voice-3.2.4.tgz",
-      "integrity": "sha512-4i3IpB/W5VxCI7BQZO5Nr2VB0ecx0SLvkln2Gy29cAQKqgBl+1ZsCwUBChwHlPbmja6vA3tp/+2ADQGwB1OhHg==",
-      "deprecated": "This package is deprecated. Use expo-speech-recognition instead.",
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "^2.0.0",
-        "invariant": "^2.2.4"
+        "merge-options": "^3.0.4"
       },
       "peerDependencies": {
-        "react-native": ">= 0.60.2"
-      }
-    },
-    "node_modules/@react-native-voice/voice/node_modules/@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/highlight": "^7.10.4"
-      }
-    },
-    "node_modules/@react-native-voice/voice/node_modules/@expo/config-plugins": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-2.0.4.tgz",
-      "integrity": "sha512-JGt/X2tFr7H8KBQrKfbGo9hmCubQraMxq5sj3bqDdKmDOLcE1a/EDCP9g0U4GHsa425J8VDIkQUHYz3h3ndEXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config-types": "^41.0.0",
-        "@expo/json-file": "8.2.30",
-        "@expo/plist": "0.0.13",
-        "debug": "^4.3.1",
-        "find-up": "~5.0.0",
-        "fs-extra": "9.0.0",
-        "getenv": "^1.0.0",
-        "glob": "7.1.6",
-        "resolve-from": "^5.0.0",
-        "slash": "^3.0.0",
-        "xcode": "^3.0.1",
-        "xml2js": "^0.4.23"
-      }
-    },
-    "node_modules/@react-native-voice/voice/node_modules/@expo/config-types": {
-      "version": "41.0.0",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-41.0.0.tgz",
-      "integrity": "sha512-Ax0pHuY5OQaSrzplOkT9DdpdmNzaVDnq9VySb4Ujq7UJ4U4jriLy8u93W98zunOXpcu0iiKubPsqD6lCiq0pig==",
-      "license": "MIT"
-    },
-    "node_modules/@react-native-voice/voice/node_modules/@expo/json-file": {
-      "version": "8.2.30",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.30.tgz",
-      "integrity": "sha512-vrgGyPEXBoFI5NY70IegusCSoSVIFV3T3ry4tjJg1MFQKTUlR7E0r+8g8XR6qC705rc2PawaZQjqXMAVtV6s2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "~7.10.4",
-        "fs-extra": "9.0.0",
-        "json5": "^1.0.1",
-        "write-file-atomic": "^2.3.0"
-      }
-    },
-    "node_modules/@react-native-voice/voice/node_modules/@expo/plist": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.13.tgz",
-      "integrity": "sha512-zGPSq9OrCn7lWvwLLHLpHUUq2E40KptUFXn53xyZXPViI0k9lbApcR9KlonQZ95C+ELsf0BQ3gRficwK92Ivcw==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.2.3",
-        "xmlbuilder": "^14.0.0",
-        "xmldom": "~0.5.0"
-      }
-    },
-    "node_modules/@react-native-voice/voice/node_modules/getenv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/getenv/-/getenv-1.0.0.tgz",
-      "integrity": "sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@react-native-voice/voice/node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@react-native-voice/voice/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/@react-native-voice/voice/node_modules/write-file-atomic": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-      "license": "ISC",
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/@react-native-voice/voice/node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/@react-native-voice/voice/node_modules/xml2js/node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/@react-native-voice/voice/node_modules/xmlbuilder": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-14.0.0.tgz",
-      "integrity": "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0"
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -4176,15 +4031,6 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "license": "MIT"
-    },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -6131,17 +5977,6 @@
         "node": ">=20.16.0"
       }
     },
-    "node_modules/expo-speech-recognition": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/expo-speech-recognition/-/expo-speech-recognition-3.1.2.tgz",
-      "integrity": "sha512-yaXy+6w218Urdshits2KsfLjXNCnGNlXzUxEP4BVehKEbiIPAeUKBzuicCeELU5H2zTLwL9u+RjbFAUom4LiYQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo-splash-screen": {
       "version": "31.0.13",
       "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-31.0.13.tgz",
@@ -6542,6 +6377,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -6619,21 +6455,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/fs.realpath": {
@@ -7549,6 +7370,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8010,27 +7840,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonfile/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -8382,6 +8191,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -8546,6 +8356,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -9492,6 +9314,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -11762,15 +11585,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/universalify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -12216,15 +12030,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/xmldom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/y18n": {

--- a/frontend/field-force-contractor/package.json
+++ b/frontend/field-force-contractor/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
-    "@react-native-voice/voice": "^3.2.4",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.2.2",
@@ -24,7 +24,6 @@
     "expo-linking": "~8.0.11",
     "expo-local-authentication": "~17.0.8",
     "expo-secure-store": "~15.0.8",
-    "expo-speech-recognition": "^3.1.2",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",
     "expo-symbols": "~1.0.8",

--- a/frontend/field-force-contractor/screens/BiometricScreen.tsx
+++ b/frontend/field-force-contractor/screens/BiometricScreen.tsx
@@ -89,9 +89,9 @@ export default function BiometricScreen() {
         await login(pendingToken, pendingUser);
         // No navigation.replace here — login() flips isAuthenticated, which
         // causes RootNavigator to swap the Auth stack out for the Protected
-        // stack. SplashScreen (the initial route in both) then routes to
-        // Inspection. Calling replace('Home') on the unmounted Auth navigator
-        // throws "Home not handled by any navigator".
+        // stack. The Protected stack opens directly at its initialRouteName
+        // (Inspection). Calling replace() on the now-unmounted Auth navigator
+        // would throw "Home not handled by any navigator".
         return;
       }
       const scanWorked = Math.random() > 0.3;

--- a/frontend/field-force-contractor/screens/BiometricScreen.tsx
+++ b/frontend/field-force-contractor/screens/BiometricScreen.tsx
@@ -87,13 +87,17 @@ export default function BiometricScreen() {
     setTimeout(async () => {
       if (DEV_MODE) {
         await login(pendingToken, pendingUser);
-        navigation.replace('Home');
+        // No navigation.replace here — login() flips isAuthenticated, which
+        // causes RootNavigator to swap the Auth stack out for the Protected
+        // stack. SplashScreen (the initial route in both) then routes to
+        // Inspection. Calling replace('Home') on the unmounted Auth navigator
+        // throws "Home not handled by any navigator".
         return;
       }
       const scanWorked = Math.random() > 0.3;
       if (scanWorked) {
         await login(pendingToken, pendingUser);
-        navigation.replace('Home');
+        // See comment above — let RootNavigator handle the stack swap.
       } else {
         setScanState('failed');
       }

--- a/frontend/field-force-contractor/screens/DriveTimeTrackerScreen.tsx
+++ b/frontend/field-force-contractor/screens/DriveTimeTrackerScreen.tsx
@@ -231,15 +231,11 @@ export default function DriveTimeTrackerScreen() {
   const logs = session?.logs ?? [];
 
   return (
-    <MainFrame>
+    <MainFrame headerMenu={["Menu2", ["Drive Time Tracker"]]}>
 
-      {/* ── Header ─────────────────────────────────────────────── */}
-      <View style={styles.headerBlock}>
-        <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
-          <Ionicons name="chevron-back" size={24} color="white" />
-        </TouchableOpacity>
-        <Text style={styles.headerTitle}>Drive Time Tracker</Text>
-      </View>
+      {/* Header is rendered by the Menu2 bar in MainFrame above
+          (back arrow + "Drive Time Tracker" title). Removed the
+          duplicate custom headerBlock that used to live here. */}
 
       {/* ── Status buttons ─────────────────────────────────────── */}
       <View style={styles.statusRow}>

--- a/frontend/field-force-contractor/screens/HomeScreen.tsx
+++ b/frontend/field-force-contractor/screens/HomeScreen.tsx
@@ -54,7 +54,15 @@ export default function HomeScreen() {
     };
 
     return (
-        <MainFrame header='home'>
+        <MainFrame header='home' headerMenu={["none", []]}>
+
+            {/* ── Title bar ──────────────────────────────────────────
+                Styled to match the Menu2 navy bar visually but with no
+                back arrow — Dashboard is the root of the authenticated
+                stack, so there's nothing meaningful to go back to. */}
+            <View style={styles.titleBar}>
+                <Text style={styles.titleBarText}>Dashboard</Text>
+            </View>
 
             {/* ── Header ── */}
             <View style={styles.header}>
@@ -183,6 +191,26 @@ const CARD_BG = 'rgba(255,255,255,0.1)';
 const BORDER  = 'rgba(255,255,255,0.15)';
 
 const styles = StyleSheet.create({
+
+    // ── Title bar (no back arrow) ─────────────────────────────
+    // Matches the Menu2 SubHeader bar visually (navy background,
+    // centered bold title) so Dashboard still has a clear section
+    // header without a misleading "back" affordance.
+    titleBar: {
+        width: '100%',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#142040',
+        paddingHorizontal: 16,
+        paddingVertical: 12,
+        marginBottom: 12,
+    },
+    titleBarText: {
+        fontSize: 18,
+        fontFamily: 'poppins-bold',
+        color: 'white',
+        letterSpacing: 0.3,
+    },
 
     header: {
         width: '90%',

--- a/frontend/field-force-contractor/screens/InspectionAssistScreen.tsx
+++ b/frontend/field-force-contractor/screens/InspectionAssistScreen.tsx
@@ -26,7 +26,7 @@ import { api } from '@/utils/api'
 type MessageType = 'sent' | 'received'
 
 type ChatMessage = {
-    id: number
+    id: string
     message: string
     messageType: MessageType
     timeStamp: string
@@ -213,7 +213,7 @@ export const InspectionAssistScreen: FC = () => {
         }
     }
 
-    const handleSaveReport = async (msgId: number, report: InspectionReport, rawNotes: string) => {
+    const handleSaveReport = async (msgId: string, report: InspectionReport, rawNotes: string) => {
         try {
             await api.authPost('/api/ai/save-report', {
                 title:               report.title,

--- a/frontend/field-force-contractor/screens/InspectionAssistScreen.tsx
+++ b/frontend/field-force-contractor/screens/InspectionAssistScreen.tsx
@@ -17,7 +17,7 @@ import {
 import { Ionicons } from '@expo/vector-icons'
 import { MainFrame } from '@/components/MainFrame'
 import { SearchBar } from '@/components/SearchBar'
-import { InitMessage } from '@/utils/InitMessage'
+import { InitID } from '@/utils/InitID'
 import { TimeFormater } from '@/utils/timeFormater'
 import { api } from '@/utils/api'
 
@@ -181,7 +181,7 @@ export const InspectionAssistScreen: FC = () => {
 
     const addMessage = (text: string, type: MessageType, reportData?: InspectionReport) => {
         setMessages(prev => [...prev, {
-            id:          InitMessage.getMessageId(),
+            id:          InitID.getId(),
             message:     text,
             messageType: type,
             timeStamp:   TimeFormater.getTimeStamp(),

--- a/frontend/field-force-contractor/screens/InspectionScreen.tsx
+++ b/frontend/field-force-contractor/screens/InspectionScreen.tsx
@@ -207,7 +207,7 @@ export default function InspectionScreen() {
   // ── Loading state ─────────────────────────────────────────────────────────
   if (loading) {
     return (
-      <MainFrame header="default" headerMenu={["none"]} footerMenu={["none"]}>
+      <MainFrame header="default" headerMenu={["none", []]} footerMenu={["none"]}>
         <View style={styles.center}>
           <ActivityIndicator size="large" color={BLUE} />
           <Text style={styles.loadingText}>Loading checklist...</Text>
@@ -220,7 +220,7 @@ export default function InspectionScreen() {
   // ── Error state ───────────────────────────────────────────────────────────
   if (error || !template) {
     return (
-      <MainFrame header="default" headerMenu={["none"]} footerMenu={["none"]}>
+      <MainFrame header="default" headerMenu={["none", []]} footerMenu={["none"]}>
         <View style={styles.center}>
           <Ionicons name="alert-circle-outline" size={48} color={RED} />
           <Text style={styles.errorText}>{error || 'No inspection template found.'}</Text>
@@ -231,9 +231,12 @@ export default function InspectionScreen() {
 
   // ── Main content ──────────────────────────────────────────────────────────
   return (
-    <MainFrame>
+    <MainFrame headerMenu={["none", []]} footerMenu={["none"]}>
 
-      {/* ── Header ─────────────────────────────────────────────────── */}
+      {/* ── Header ──────────────────────────────────────────────────
+          Styled to match the Menu2 navy bar visually but with no back
+          arrow — this screen is the daily inspection gate, navigating
+          back out of it doesn't make sense. */}
       <View style={styles.headerBlock}>
         <Text style={styles.headerTitle}>Inspection Required</Text>
       </View>
@@ -379,16 +382,23 @@ const styles = StyleSheet.create({
   errorText:   { color: RED, fontSize: 14, fontFamily: 'poppins-regular', textAlign: 'center' },
 
   // ── Header ──────────────────────────────────────────────────────────────
+  // Matches the Menu2 SubHeader bar visually (navy background, centered
+  // bold title) but with no back arrow — this is the inspection gate and
+  // navigating back out of it is intentionally disallowed.
   headerBlock: {
-    width: '90%',
+    width: '100%',
     alignItems: 'center',
-    marginTop: 12,
-    marginBottom: 8,
+    justifyContent: 'center',
+    backgroundColor: '#142040',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    marginBottom: 12,
   },
   headerTitle: {
     fontSize: 18,
     fontFamily: 'poppins-bold',
     color: 'white',
+    letterSpacing: 0.3,
   },
 
   // ── Truck card ──────────────────────────────────────────────────────────

--- a/frontend/field-force-contractor/screens/LoginScreen.tsx
+++ b/frontend/field-force-contractor/screens/LoginScreen.tsx
@@ -65,7 +65,7 @@ const fieldConfig = FIELD_CONFIG[LOGIN_FIELD];
 //  true  = any non-empty username + password (6+ chars) succeeds immediately.
 //  Set to false when the backend is ready.
 // ─────────────────────────────────────────────────────────────────────────────
-const DEV_MODE = true;
+const DEV_MODE = false;
 
 const isValidEmail = (value: string) => {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;

--- a/frontend/field-force-contractor/screens/OfflineLoginScreen.tsx
+++ b/frontend/field-force-contractor/screens/OfflineLoginScreen.tsx
@@ -80,7 +80,11 @@ export default function OfflineLoginScreen() {
       setPinError('Incorrect PIN. Please try again.');
       return;
     }
-    navigation.replace('Home');
+    // TODO (Troy): this needs to call useAuth().login(storedToken, storedUser)
+    // so isAuthenticated flips and RootNavigator swaps to the Protected stack.
+    // Right now replace('Home') targets the Auth navigator which has no Home,
+    // so it will throw "Home not handled by any navigator".
+    navigation.replace('Home' as any);
   };
 
   // ── Reset PIN modal handlers ──────────────────────────────

--- a/frontend/field-force-contractor/screens/OfflineLoginScreen.tsx
+++ b/frontend/field-force-contractor/screens/OfflineLoginScreen.tsx
@@ -80,11 +80,11 @@ export default function OfflineLoginScreen() {
       setPinError('Incorrect PIN. Please try again.');
       return;
     }
-    // TODO (Troy): this needs to call useAuth().login(storedToken, storedUser)
-    // so isAuthenticated flips and RootNavigator swaps to the Protected stack.
-    // Right now replace('Home') targets the Auth navigator which has no Home,
-    // so it will throw "Home not handled by any navigator".
-    navigation.replace('Home' as any);
+    // TODO (Troy): when offline auth is implemented, complete the auth flow
+    // here (e.g. restore stored token/user and call useAuth().login(...)) so
+    // the Protected stack mounts naturally. Until then redirect to a route
+    // that exists in the unauthenticated stack.
+    navigation.replace('Login' as any);
   };
 
   // ── Reset PIN modal handlers ──────────────────────────────

--- a/frontend/field-force-contractor/screens/SplashScreen.tsx
+++ b/frontend/field-force-contractor/screens/SplashScreen.tsx
@@ -50,9 +50,10 @@ export const SplashScreen: FC = () => {
 
       if (isAuthenticated) {
         // Valid unexpired token — skip login entirely
+        // Go to Inspection (the daily safety gate + designed entry point).
         // replace() removes SplashScreen from the stack so it can never
-        // fire navigation again after the user is in the app
-        nav.replace('Home' as any);
+        // fire navigation again after the user is in the app.
+        nav.replace('Inspection' as any);
       } else {
         // No token or expired — go to Login
         nav.replace('Login' as any);

--- a/frontend/field-force-contractor/screens/SplashScreen.tsx
+++ b/frontend/field-force-contractor/screens/SplashScreen.tsx
@@ -1,17 +1,14 @@
 // SplashScreen.tsx  —  Jonathan
 //
-// Shows the Field Force logo for 3 seconds on app launch, then routes
-// based on whether the user has a valid existing session:
+// Shows the Field Force logo for 3 seconds on cold start, then routes
+// to Login. SplashScreen is only registered in the unauthenticated stack
+// (App.tsx), so isAuthenticated is always false here — no branch needed.
 //
-//   Valid token found → Home   (user stays logged in, skips login)
-//   No token / expired → Login (user must log in again)
+// If the user has a valid stored token, AuthContext restores it on mount
+// and the protected stack (Inspection-first) renders directly — Splash
+// is never shown for returning users.
 //
 // ── IMPORTANT: WHY replace() AND NOT navigate() ───────────────────────────────
-// Using navigate() leaves SplashScreen in the navigation stack. If anything
-// later changes isAuthenticated (e.g. login() being called after biometrics),
-// the useEffect would fire again, start a new timer, and navigate the user back
-// to Home mid-session — pulling them off whatever screen they were on.
-//
 // replace() removes SplashScreen from the stack entirely when it routes. It
 // can never fire again after that because it is no longer mounted.
 //
@@ -31,7 +28,7 @@ import { useAuth }                from "@/contexts/AuthContext";
 
 export const SplashScreen: FC = () => {
   const nav  = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-  const { isAuthenticated, isLoading } = useAuth();
+  const { isLoading } = useAuth();
 
   // Prevents multiple navigations if the effect fires more than once
   const hasNavigated = useRef(false);
@@ -48,24 +45,13 @@ export const SplashScreen: FC = () => {
       if (hasNavigated.current) return;
       hasNavigated.current = true;
 
-      if (isAuthenticated) {
-        // Valid unexpired token — skip login entirely
-        // Go to Inspection (the daily safety gate + designed entry point).
-        // replace() removes SplashScreen from the stack so it can never
-        // fire navigation again after the user is in the app.
-        nav.replace('Inspection' as any);
-      } else {
-        // No token or expired — go to Login
-        nav.replace('Login' as any);
-      }
+      // SplashScreen is only in the unauthenticated stack — always go to Login.
+      // Authenticated users skip Splash entirely: the protected stack mounts
+      // with Inspection as its initialRouteName (see App.tsx RootNavigator).
+      nav.replace('Login' as any);
     }, SPLASH_TIME);
 
     return () => clearTimeout(timer);
-
-    // Only isLoading is a dependency — we intentionally do NOT include
-    // isAuthenticated here. We read it once when isLoading becomes false.
-    // If isAuthenticated were a dependency, any later call to login() would
-    // re-trigger this effect and navigate the user mid-session.
   }, [isLoading]);
 
   return (


### PR DESCRIPTION
## Summary
Expo Go has been crashing with `java.io.IOException` on load since yesterday's merges. Root cause: two libraries in `package.json` / `app.json` plugins that are not supported by Expo Go's bundled native runtime.

- `@react-native-voice/voice` — bare React Native module, requires native linking (never Expo Go compatible)
- `expo-speech-recognition` — third-party Expo module, not bundled in Expo Go's fixed runtime

Both register native modules at JS bundle eval time, which throws when Expo Go can't find the native side. Prebuild / dev-client work because `expo prebuild` generates actual native project code linking them in.

Grepped the entire frontend — **no source file imports either library**. The mic button in `TicketDetailScreen` is a placeholder that only shows a "Coming Soon" alert. Both libraries were dead weight from a previous merge.

## Changes
- Removed `@react-native-voice/voice` from `package.json`
- Removed `expo-speech-recognition` from `package.json`
- Removed `expo-speech-recognition` from `app.json` plugins
- Regenerated `package-lock.json` (20 transitive deps dropped)
- Kept `RECORD_AUDIO` / `NSMicrophoneUsageDescription` permissions so speech can be reintroduced later through a dev-client build without another config churn

## Test plan
- [ ] Pull, `rm -rf node_modules`, `npm ci`, `npx expo start -c`
- [ ] App loads in Expo Go without `java.io.IOException`
- [ ] All existing flows still work (login → biometrics → Inspection → Dashboard)
- [ ] Prebuild / dev-client still work unchanged