### PR TITLE
Add soft session lock when app backgrounds

### DIFF
--- a/backend/flask_app.py
+++ b/backend/flask_app.py
@@ -12,18 +12,6 @@ config = 'ProductionConfig' if os.environ.get('RENDER') else 'DevelopmentConfig'
 app = create_app(config)
 
 with app.app_context():
-    # ONE-TIME schema reset: drop inspections + results tables so create_all()
-    # rebuilds them with the current model (notes, skipped, no_issues_found cols).
-    # Safe to run repeatedly — CASCADE handles the FK constraint ordering.
-    # Revert this block to just db.create_all() after the next deploy lands.
-    from sqlalchemy import text, inspect as sa_inspect
-    inspector = sa_inspect(db.engine)
-    existing = inspector.get_table_names()
-    if 'inspection_results' in existing or 'inspections' in existing:
-        with db.engine.connect() as conn:
-            conn.execute(text('DROP TABLE IF EXISTS inspection_results CASCADE'))
-            conn.execute(text('DROP TABLE IF EXISTS inspections CASCADE'))
-            conn.commit()
     db.create_all()
 
 if __name__ == '__main__':

--- a/backend/flask_app.py
+++ b/backend/flask_app.py
@@ -12,6 +12,18 @@ config = 'ProductionConfig' if os.environ.get('RENDER') else 'DevelopmentConfig'
 app = create_app(config)
 
 with app.app_context():
+    # ONE-TIME schema reset: drop inspections + results tables so create_all()
+    # rebuilds them with the current model (notes, skipped, no_issues_found cols).
+    # Safe to run repeatedly — CASCADE handles the FK constraint ordering.
+    # Revert this block to just db.create_all() after the next deploy lands.
+    from sqlalchemy import text, inspect as sa_inspect
+    inspector = sa_inspect(db.engine)
+    existing = inspector.get_table_names()
+    if 'inspection_results' in existing or 'inspections' in existing:
+        with db.engine.connect() as conn:
+            conn.execute(text('DROP TABLE IF EXISTS inspection_results CASCADE'))
+            conn.execute(text('DROP TABLE IF EXISTS inspections CASCADE'))
+            conn.commit()
     db.create_all()
 
 if __name__ == '__main__':

--- a/frontend/field-force-contractor/App.tsx
+++ b/frontend/field-force-contractor/App.tsx
@@ -1,92 +1,102 @@
-import { useEffect, useState } from "react";
-import { TextInput, View, ActivityIndicator } from "react-native";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  AppState,
+  AppStateStatus,
+  TextInput,
+  View,
+} from "react-native";
 import { LoadFonts } from "./utils/LoadFonts";
 
 // Dark translucent keyboard on iOS for every TextInput in the app
 (TextInput as any).defaultProps = {
   ...((TextInput as any).defaultProps ?? {}),
-  keyboardAppearance: 'dark',
+  keyboardAppearance: "dark",
 };
 
-import { NavigationContainer } from '@react-navigation/native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { AuthProvider, useAuth } from './contexts/AuthContext';
-import { ThemeProvider } from './contexts/ThemeContext';
+import { NavigationContainer } from "@react-navigation/native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { AuthProvider, useAuth } from "./contexts/AuthContext";
+import { ThemeProvider } from "./contexts/ThemeContext";
 
 // ── Jonathan ──────────────────────────────────────
-import {Blank} from "./screens/Blank";
-import HomeScreen from "./screens/HomeScreen"
-import {screenConfig} from "./constants/ScreenConfig";
+import { screenConfig } from "./constants/ScreenConfig";
+import { Blank } from "./screens/Blank";
+import { Chat } from "./screens/ChatScreen";
 import { Contacts } from "./screens/ContactScreen";
-import { SplashScreen } from "./screens/SplashScreen";
-import {Chat} from "./screens/ChatScreen";
-import TicketsScreen from "./screens/TicketsScreen";
-import TicketDetailScreen from "./screens/TicketDetailScreen";
-import InspectionScreen from "./screens/InspectionScreen";
-import { InspectionAssistScreen } from "./screens/InspectionAssistScreen";
 import DriveTimeTrackerScreen from "./screens/DriveTimeTrackerScreen";
+import HomeScreen from "./screens/HomeScreen";
+import { InspectionAssistScreen } from "./screens/InspectionAssistScreen";
+import InspectionScreen from "./screens/InspectionScreen";
 import { SavedReportsScreen } from "./screens/SavedReportsScreen";
+import SessionLockScreen from "./screens/SessionLockScreen";
+import { SplashScreen } from "./screens/SplashScreen";
+import TicketDetailScreen from "./screens/TicketDetailScreen";
+import TicketsScreen from "./screens/TicketsScreen";
 
 // ── TROY — Auth screens ──────────────────────────────────────
-import LoginScreen           from "./screens/LoginScreen";
-import OfflineLoginScreen    from "./screens/OfflineLoginScreen";
-import BiometricScreen       from "./screens/BiometricScreen";
-import PasswordResetScreen   from "./screens/PasswordResetScreen";
+import BiometricScreen from "./screens/BiometricScreen";
+import LoginScreen from "./screens/LoginScreen";
+import OfflineLoginScreen from "./screens/OfflineLoginScreen";
 import OfflinePinResetScreen from "./screens/OfflinePinResetScreen";
+import PasswordResetScreen from "./screens/PasswordResetScreen";
 
 // ── TROY — Profile screens ───────────────────────────────────
-import ProfileScreen     from "./screens/ProfileScreen";
-import LicenseScreen     from "./screens/LicenseScreen";
+import LicenseScreen from "./screens/LicenseScreen";
+import ProfileScreen from "./screens/ProfileScreen";
 import TaskHistoryScreen from "./screens/TaskHistoryScreen";
 
 export type RootStackParamList = {
   // ── Always visible ───────────────────────────────────────────
-  SplashScreen:  undefined;
+  SplashScreen: undefined;
 
   // ── Jonathan — App screens ───────────────────────────────────
-  Home:          undefined;
-  Blank:         undefined;
+  Home: undefined;
+  Blank: undefined;
   // ── Charlie — App screens ───────────────────────────────────
-  Contacts:      undefined;
-  Chat:          { name: string; contactId?: string };
-  Tickets:       undefined;
-  TicketDetail:  { taskId: number };
+  Contacts: undefined;
+  Chat: { name: string; contactId?: string };
+  Tickets: undefined;
+  TicketDetail: { taskId: number };
 
   // ── Jonathan — Work Orders (placeholder until real screen built) ──
-  JobDetail:     { jobId: string; workOrderId: string };
+  JobDetail: { jobId: string; workOrderId: string };
   // ── Charlie — Work Orders (placeholder until real screen built) ──
-  WorkOrders:    undefined;
+  WorkOrders: undefined;
 
   // ── Troy — Auth screens ──────────────────────────────────────
-  Login:           undefined;
-  OfflineLogin:    undefined;
+  Login: undefined;
+  OfflineLogin: undefined;
 
   // BiometricCheck receives the pending token and user from LoginScreen.
   // login() is NOT called until the biometric scan succeeds here, ensuring
   // isAuthenticated never becomes true before identity is verified.
   BiometricCheck: {
     pendingToken: string;
-    pendingUser:  { id: number; username: string; role: string };
+    pendingUser: { id: number; username: string; role: string };
   };
 
-  PasswordReset:   undefined;
+  PasswordReset: undefined;
   OfflinePinReset: undefined;
 
   // ── Troy — Profile screens ───────────────────────────────────
-  Profile:         undefined;
-  LicenseDetails:  undefined;
-  TaskHistory:     undefined;
+  Profile: undefined;
+  LicenseDetails: undefined;
+  TaskHistory: undefined;
 
   // ── Aldo — Inspection screen + AI assist + Drive Time ────────
-  Inspection:        { bypassGate?: boolean } | undefined;
-  InspectionAssist:  undefined;
-  DriveTimeTracker:  undefined;
+  Inspection: { bypassGate?: boolean } | undefined;
+  InspectionAssist: undefined;
+  DriveTimeTracker: undefined;
 
   // ── Aldo — Saved Reports ─────────────────────────────────────
   SavedReports: undefined;
 
+  // ── Session lock ─────────────────────────────────────────────
+  SessionLock: undefined;
+
   // ── Charlie — Dashboard (placeholder until real screen is built) ──
-  Dashboard:       undefined;
+  Dashboard: undefined;
 };
 
 const StackNavigator = createNativeStackNavigator();
@@ -97,11 +107,49 @@ const StackNavigator = createNativeStackNavigator();
 // React Navigation automatically transitions between stacks when isAuthenticated changes.
 function RootNavigator() {
   const { isAuthenticated, isLoading } = useAuth();
+  const [isSessionLocked, setIsSessionLocked] = useState(false);
+  const appStateRef = useRef<AppStateStatus>(AppState.currentState);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setIsSessionLocked(false);
+    }
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", (nextAppState) => {
+      const prevAppState = appStateRef.current;
+
+      // Soft-lock authenticated sessions when app leaves the foreground.
+      if (
+        isAuthenticated &&
+        prevAppState === "active" &&
+        (nextAppState === "inactive" || nextAppState === "background")
+      ) {
+        setIsSessionLocked(true);
+      }
+
+      appStateRef.current = nextAppState;
+    });
+
+    return () => subscription.remove();
+  }, [isAuthenticated]);
+
+  const handleSessionUnlock = useCallback(() => {
+    setIsSessionLocked(false);
+  }, []);
 
   // Still reading token from SecureStore — show a branded loading screen
   if (isLoading) {
     return (
-      <View style={{ flex: 1, backgroundColor: '#0a0a0a', alignItems: 'center', justifyContent: 'center' }}>
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: "#0a0a0a",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
         <ActivityIndicator size="large" color="#3b82f6" />
       </View>
     );
@@ -110,7 +158,7 @@ function RootNavigator() {
   return (
     <StackNavigator.Navigator
       screenOptions={screenConfig.window}
-      initialRouteName={isAuthenticated ? 'Inspection' : 'SplashScreen'}
+      initialRouteName={isAuthenticated ? "Inspection" : "SplashScreen"}
     >
       {isAuthenticated ? (
         // ── Protected App screens ─────────────────────────────────────────
@@ -119,34 +167,73 @@ function RootNavigator() {
         // Splash registered across both stacks caused React Navigation to
         // fall back to it after the swap, where a stale closure in its
         // useEffect would navigate the user back to Login.
-        <>
-          <StackNavigator.Screen name="Inspection"       component={InspectionScreen}       />
-          <StackNavigator.Screen name="Dashboard"        component={HomeScreen}              />
-          <StackNavigator.Screen name="Home"             component={HomeScreen}              />
-          <StackNavigator.Screen name="Blank"            component={Blank}                   />
-          <StackNavigator.Screen name="Contacts"         component={Contacts}                />
-          <StackNavigator.Screen name="Chat"             component={Chat}                    />
-          <StackNavigator.Screen name="Tickets"          component={TicketsScreen}           />
-          <StackNavigator.Screen name="TicketDetail"     component={TicketDetailScreen}      />
-          <StackNavigator.Screen name="Profile"          component={ProfileScreen}           />
-          <StackNavigator.Screen name="LicenseDetails"   component={LicenseScreen}           />
-          <StackNavigator.Screen name="TaskHistory"      component={TaskHistoryScreen}       />
-          <StackNavigator.Screen name="InspectionAssist" component={InspectionAssistScreen}  />
-          <StackNavigator.Screen name="DriveTimeTracker" component={DriveTimeTrackerScreen}  />
-          <StackNavigator.Screen name="SavedReports"     component={SavedReportsScreen}      />
-        </>
+        isSessionLocked ? (
+          <StackNavigator.Screen name="SessionLock">
+            {() => <SessionLockScreen onUnlock={handleSessionUnlock} />}
+          </StackNavigator.Screen>
+        ) : (
+          <>
+            <StackNavigator.Screen
+              name="Inspection"
+              component={InspectionScreen}
+            />
+            <StackNavigator.Screen name="Dashboard" component={HomeScreen} />
+            <StackNavigator.Screen name="Home" component={HomeScreen} />
+            <StackNavigator.Screen name="Blank" component={Blank} />
+            <StackNavigator.Screen name="Contacts" component={Contacts} />
+            <StackNavigator.Screen name="Chat" component={Chat} />
+            <StackNavigator.Screen name="Tickets" component={TicketsScreen} />
+            <StackNavigator.Screen
+              name="TicketDetail"
+              component={TicketDetailScreen}
+            />
+            <StackNavigator.Screen name="Profile" component={ProfileScreen} />
+            <StackNavigator.Screen
+              name="LicenseDetails"
+              component={LicenseScreen}
+            />
+            <StackNavigator.Screen
+              name="TaskHistory"
+              component={TaskHistoryScreen}
+            />
+            <StackNavigator.Screen
+              name="InspectionAssist"
+              component={InspectionAssistScreen}
+            />
+            <StackNavigator.Screen
+              name="DriveTimeTracker"
+              component={DriveTimeTrackerScreen}
+            />
+            <StackNavigator.Screen
+              name="SavedReports"
+              component={SavedReportsScreen}
+            />
+          </>
+        )
       ) : (
         // ── Public Auth screens ───────────────────────────────────────────
         // Login is the entry point after Splash. After a successful login()
         // call the auth state flips and React Navigation auto-routes to
         // Inspection above.
         <>
-          <StackNavigator.Screen name="SplashScreen"    component={SplashScreen}          />
-          <StackNavigator.Screen name="Login"           component={LoginScreen}           />
-          <StackNavigator.Screen name="OfflineLogin"    component={OfflineLoginScreen}    />
-          <StackNavigator.Screen name="BiometricCheck"  component={BiometricScreen}       />
-          <StackNavigator.Screen name="PasswordReset"   component={PasswordResetScreen}   />
-          <StackNavigator.Screen name="OfflinePinReset" component={OfflinePinResetScreen} />
+          <StackNavigator.Screen name="SplashScreen" component={SplashScreen} />
+          <StackNavigator.Screen name="Login" component={LoginScreen} />
+          <StackNavigator.Screen
+            name="OfflineLogin"
+            component={OfflineLoginScreen}
+          />
+          <StackNavigator.Screen
+            name="BiometricCheck"
+            component={BiometricScreen}
+          />
+          <StackNavigator.Screen
+            name="PasswordReset"
+            component={PasswordResetScreen}
+          />
+          <StackNavigator.Screen
+            name="OfflinePinReset"
+            component={OfflinePinResetScreen}
+          />
         </>
       )}
     </StackNavigator.Navigator>

--- a/frontend/field-force-contractor/screens/SessionLockScreen.tsx
+++ b/frontend/field-force-contractor/screens/SessionLockScreen.tsx
@@ -1,0 +1,204 @@
+import { Ionicons } from "@expo/vector-icons";
+import * as LocalAuthentication from "expo-local-authentication";
+import { useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+import { MainFrame } from "../components/MainFrame";
+import { colors, fontSize, fonts, radius, spacing } from "../constants/theme";
+
+interface SessionLockScreenProps {
+  onUnlock: () => void;
+}
+
+export default function SessionLockScreen({
+  onUnlock,
+}: SessionLockScreenProps) {
+  const [isUnlocking, setIsUnlocking] = useState(false);
+  const [errorText, setErrorText] = useState("");
+
+  const handleUnlock = async () => {
+    if (isUnlocking) return;
+
+    setIsUnlocking(true);
+    setErrorText("");
+
+    try {
+      const hasHardware = await LocalAuthentication.hasHardwareAsync();
+      const enrolled = await LocalAuthentication.isEnrolledAsync();
+
+      if (!hasHardware || !enrolled) {
+        setErrorText(
+          "Biometric or device passcode is not configured on this device.",
+        );
+        return;
+      }
+
+      const result = await LocalAuthentication.authenticateAsync({
+        promptMessage: "Authenticate to continue",
+        cancelLabel: "Cancel",
+      });
+
+      if (result.success) {
+        onUnlock();
+      } else if (
+        result.error !== "user_cancel" &&
+        result.error !== "system_cancel"
+      ) {
+        setErrorText("Authentication failed. Please try again.");
+      }
+    } catch {
+      setErrorText(
+        "Authentication is currently unavailable. Please try again.",
+      );
+    } finally {
+      setIsUnlocking(false);
+    }
+  };
+
+  useEffect(() => {
+    handleUnlock();
+  }, []);
+
+  return (
+    <MainFrame
+      header="default"
+      headerMenu={["Menu2", ["Session Locked"]]}
+      footerMenu={["none", []]}
+    >
+      <StatusBar
+        barStyle="light-content"
+        backgroundColor="transparent"
+        translucent
+      />
+
+      <View style={styles.container}>
+        <View style={styles.iconWrap}>
+          <Ionicons name="lock-closed" size={64} color={colors.primary} />
+        </View>
+
+        <Text style={styles.title}>Session Locked</Text>
+        <Text style={styles.subtitle}>
+          Please authenticate to continue your active session.
+        </Text>
+
+        {errorText !== "" && (
+          <View style={styles.errorBanner}>
+            <Ionicons
+              name="alert-circle-outline"
+              size={16}
+              color={colors.error}
+            />
+            <Text style={styles.errorText}>{errorText}</Text>
+          </View>
+        )}
+
+        <TouchableOpacity
+          style={[styles.unlockBtn, isUnlocking && styles.unlockBtnDisabled]}
+          onPress={handleUnlock}
+          activeOpacity={0.85}
+          disabled={isUnlocking}
+        >
+          {isUnlocking ? (
+            <ActivityIndicator color={colors.textWhite} />
+          ) : (
+            <>
+              <Ionicons
+                name="finger-print"
+                size={18}
+                color={colors.textWhite}
+              />
+              <Text style={styles.unlockText}>Unlock</Text>
+            </>
+          )}
+        </TouchableOpacity>
+      </View>
+    </MainFrame>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    width: "100%",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: spacing.lg,
+    gap: spacing.md,
+  },
+
+  iconWrap: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.primaryFaint,
+    borderWidth: 1,
+    borderColor: colors.border,
+    marginBottom: spacing.sm,
+  },
+
+  title: {
+    fontFamily: fonts.bold,
+    fontSize: fontSize.xl,
+    color: colors.textWhite,
+    letterSpacing: 1,
+  },
+
+  subtitle: {
+    fontFamily: fonts.regular,
+    fontSize: fontSize.md,
+    color: colors.textLight,
+    textAlign: "center",
+    maxWidth: 320,
+  },
+
+  errorBanner: {
+    marginTop: spacing.sm,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: colors.errorBorder,
+    backgroundColor: colors.errorBg,
+  },
+
+  errorText: {
+    fontFamily: fonts.regular,
+    fontSize: fontSize.sm,
+    color: colors.errorTitle,
+  },
+
+  unlockBtn: {
+    marginTop: spacing.md,
+    minWidth: 180,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    paddingVertical: 12,
+    paddingHorizontal: spacing.lg,
+    borderRadius: radius.md,
+    backgroundColor: colors.primary,
+  },
+
+  unlockBtnDisabled: {
+    opacity: 0.7,
+  },
+
+  unlockText: {
+    fontFamily: fonts.bold,
+    fontSize: fontSize.base,
+    color: colors.textWhite,
+  },
+});


### PR DESCRIPTION
## Summary
Adds a soft-lock flow for authenticated users when the app leaves the foreground.

## What changed
- Added AppState-based lock trigger in App navigator.
- Added a dedicated SessionLock screen that requires local authentication to continue.
- Preserved existing auth token/session (no forced logout).

## Behavior
- When app moves from active to inactive/background, session becomes locked.
- On return, user must unlock with biometrics/device authentication.
- Successful unlock resumes the same authenticated session.
