### PR TITLE
Feat/dev mode

### DIFF
--- a/frontend/field-force-contractor/App.tsx
+++ b/frontend/field-force-contractor/App.tsx
@@ -18,7 +18,7 @@ import { screenConfig } from "./constants/ScreenConfig";
 import { Chat } from "./screens/ChatScreen";
 import { Contacts } from "./screens/ContactScreen";
 import { SplashScreen} from "./screens/SplashScreen";
-import { AppProvider} from "./contexts/AppContext";
+import { AppContext, AppProvider} from "./contexts/AppContext";
 import DriveTimeTrackerScreen from "./screens/DriveTimeTrackerScreen";
 import HomeScreen from "./screens/HomeScreen";
 import { InspectionAssistScreen } from "./screens/InspectionAssistScreen";
@@ -40,7 +40,12 @@ import PasswordResetScreen from "./screens/PasswordResetScreen";
 import LicenseScreen from "./screens/LicenseScreen";
 import ProfileScreen from "./screens/ProfileScreen";
 import TaskHistoryScreen from "./screens/TaskHistoryScreen";
-
+export type OnSuccessRoute = {
+  [K in keyof RootStackParamList]:
+    undefined extends RootStackParamList[K]
+      ? { screen: K; params?: RootStackParamList[K] }
+      : { screen: K; params: RootStackParamList[K] }
+}[keyof RootStackParamList];
 export type RootStackParamList = {
   // ── Always visible ───────────────────────────────────────────
   SplashScreen: undefined;
@@ -69,6 +74,7 @@ export type RootStackParamList = {
   BiometricCheck: {
     pendingToken: string;
     pendingUser: { id: number; username: string; role: string };
+    onSuccess?: OnSuccessRoute
   };
 
   PasswordReset: undefined;
@@ -155,12 +161,16 @@ function RootNavigator() {
 // ── App root ───────────────────────────────────────────────────────────────
 export default function App() {
   const [externalFontsLoaded, setExternalFontsLoaded] = useState(false);
+ 
   useEffect(() => {
+  
+    
     const load = async () => {
       const isLoaded = await LoadFonts();
       setExternalFontsLoaded(isLoaded);
     };
     load();
+    
   }, []);
 
   if (!externalFontsLoaded) return null;

--- a/frontend/field-force-contractor/components/MainFrame.tsx
+++ b/frontend/field-force-contractor/components/MainFrame.tsx
@@ -117,7 +117,7 @@ type Props = {
 export const MainFrame: FC<Props> = (props) => {
   const route    = useRoute();
   const pageName = route.name;
-  const [mount] = useContext(AppContext);
+  const {mount,devMode} = useContext(AppContext);
   const {isAuthenticated,isLoading} = useAuth();
  type Nav = NativeStackNavigationProp<RootStackParamList>;
  const publicPages = [
@@ -139,15 +139,17 @@ export const MainFrame: FC<Props> = (props) => {
      
       const noAuthRequired =  publicPages.some(item => item.name === pageName)
       const notLogin = pageName !== "Login"
-         
-      if(!isAuthenticated && notLogin){
+      if(devMode === false){
+        if(!isAuthenticated && notLogin){
 
-         if( requireAuth === true || !noAuthRequired && requireAuth == undefined) {
-          hasRedirected.current = true
-          navigator.replace("Login")
-         }
+          if( requireAuth === true || !noAuthRequired && requireAuth == undefined) {
+            hasRedirected.current = true
+            navigator.replace("Login")
+          }
 
-        }
+          }
+      }
+      
       
   
 

--- a/frontend/field-force-contractor/contexts/AppContext.tsx
+++ b/frontend/field-force-contractor/contexts/AppContext.tsx
@@ -9,6 +9,7 @@ export const AppProvider = ({children} : {children:ReactNode}) =>{
    const [mount,setMounted] = useState(false);
    const [reverseStack,setReverseStack] = useState(false);
    const [devMode,setDevMode] = useState(true);
+  
     return(
 
         <AppContext.Provider value={{mount,setMounted,reverseStack,setReverseStack,devMode,setDevMode}}>

--- a/frontend/field-force-contractor/contexts/AppContext.tsx
+++ b/frontend/field-force-contractor/contexts/AppContext.tsx
@@ -8,7 +8,7 @@ export const  AppContext = createContext<any>(null)
 export const AppProvider = ({children} : {children:ReactNode}) =>{
    const [mount,setMounted] = useState(false);
    const [reverseStack,setReverseStack] = useState(false);
-   const [devMode,setDevMode] = useState(false);
+   const [devMode,setDevMode] = useState(true);
     return(
 
         <AppContext.Provider value={{mount,setMounted,reverseStack,setReverseStack,devMode,setDevMode}}>

--- a/frontend/field-force-contractor/contexts/AppContext.tsx
+++ b/frontend/field-force-contractor/contexts/AppContext.tsx
@@ -8,9 +8,10 @@ export const  AppContext = createContext<any>(null)
 export const AppProvider = ({children} : {children:ReactNode}) =>{
    const [mount,setMounted] = useState(false);
    const [reverseStack,setReverseStack] = useState(false);
+   const [devMode,setDevMode] = useState(false);
     return(
 
-        <AppContext.Provider value={{mount,setMounted,reverseStack,setReverseStack}}>
+        <AppContext.Provider value={{mount,setMounted,reverseStack,setReverseStack,devMode,setDevMode}}>
         {children}
         </AppContext.Provider>
     )

--- a/frontend/field-force-contractor/contexts/AppContext.tsx
+++ b/frontend/field-force-contractor/contexts/AppContext.tsx
@@ -8,7 +8,7 @@ export const  AppContext = createContext<any>(null)
 export const AppProvider = ({children} : {children:ReactNode}) =>{
    const [mount,setMounted] = useState(false);
    const [reverseStack,setReverseStack] = useState(false);
-   const [devMode,setDevMode] = useState(true);
+   const [devMode,setDevMode] = useState(false);
   
     return(
 

--- a/frontend/field-force-contractor/screens/BiometricScreen.tsx
+++ b/frontend/field-force-contractor/screens/BiometricScreen.tsx
@@ -35,7 +35,7 @@ import { Ionicons }  from '@expo/vector-icons';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp }          from '@react-navigation/native-stack';
 
-import { RootStackParamList }     from '../App';
+import { RootStackParamList,OnSuccessRoute }     from '../App';
 import { MainFrame } from '../components/MainFrame';
 import { SETTINGS_BIOMETRIC_KEY } from './ProfileScreen';
 import { useAuth }                from '../contexts/AuthContext';
@@ -53,7 +53,7 @@ export default function BiometricScreen() {
   const { login }            = useAuth();
 
   // Pending credentials passed from LoginScreen — not yet committed to AuthContext
-  const { pendingToken, pendingUser } = route.params;
+  const { pendingToken, pendingUser,onSuccess } = route.params;
 
   const [isOffline,      setIsOffline]      = useState(false);
   const [scanState,      setScanState]      = useState('idle');
@@ -79,7 +79,13 @@ export default function BiometricScreen() {
     setSelectedMethod(method);
     setScanState('idle');
   };
-
+  const go = (route: OnSuccessRoute) => {
+            if ("params" in route) {
+              navigation.replace(route.screen as any, route.params as any);
+            } else {
+              navigation.replace(route.screen as any);
+            }
+          };
   const handleScan = async () => {
     if (scanState === 'scanning') return;
     setScanState('scanning');
@@ -92,12 +98,22 @@ export default function BiometricScreen() {
         // stack. The Protected stack opens directly at its initialRouteName
         // (Inspection). Calling replace() on the now-unmounted Auth navigator
         // would throw "Home not handled by any navigator".
-        return;
+        if(onSuccess){
+          go(onSuccess);
+        }else{
+          return;
+        }
+        
       }
       const scanWorked = Math.random() > 0.3;
       if (scanWorked) {
         await login(pendingToken, pendingUser);
         // See comment above — let RootNavigator handle the stack swap.
+       if(onSuccess){
+        go(onSuccess);
+       }else{
+        return;
+       }
       } else {
         setScanState('failed');
       }

--- a/frontend/field-force-contractor/screens/LoginScreen.tsx
+++ b/frontend/field-force-contractor/screens/LoginScreen.tsx
@@ -65,7 +65,7 @@ const fieldConfig = FIELD_CONFIG[LOGIN_FIELD];
 //  true  = any non-empty username + password (6+ chars) succeeds immediately.
 //  Set to false when the backend is ready.
 // ─────────────────────────────────────────────────────────────────────────────
-const DEV_MODE = false;
+const DEV_MODE = true;
 
 const isValidEmail = (value: string) => {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -158,6 +158,7 @@ export default function LoginScreen() {
         navigation.navigate('BiometricCheck', {
           pendingToken: 'dev-token',
           pendingUser:  { id: 0, username: identifier.trim(), role: 'contractor' },
+          onSuccess:{screen:"Home"}
         });
         return;
       }
@@ -171,6 +172,7 @@ export default function LoginScreen() {
       navigation.navigate('BiometricCheck', {
         pendingToken: res.token,
         pendingUser:  res.user,
+        onSuccess:{screen:"Home"}
       });
 
     } catch (err) {

--- a/frontend/field-force-contractor/screens/LoginScreen.tsx
+++ b/frontend/field-force-contractor/screens/LoginScreen.tsx
@@ -65,7 +65,7 @@ const fieldConfig = FIELD_CONFIG[LOGIN_FIELD];
 //  true  = any non-empty username + password (6+ chars) succeeds immediately.
 //  Set to false when the backend is ready.
 // ─────────────────────────────────────────────────────────────────────────────
-const DEV_MODE = true;
+const DEV_MODE = false;
 
 const isValidEmail = (value: string) => {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;

--- a/frontend/field-force-contractor/screens/SplashScreen.tsx
+++ b/frontend/field-force-contractor/screens/SplashScreen.tsx
@@ -48,13 +48,23 @@ export const SplashScreen: FC = () => {
     }
     if(devMode === false){
       if (isAuthenticated) {
-        nav.replace('Home');
+        
+        nav.replace('BiometricCheck',{
+          pendingToken: 'dev-token',
+          pendingUser:  { id: 0, username: "DevMode", role: 'contractor' },
+          onSuccess:{screen:"Home"}
+        });
       } else {
         nav.replace('Login');
       }
     }
     else{
-      nav.replace("Home");
+       nav.replace('BiometricCheck',{
+          pendingToken: 'dev-token',
+          pendingUser:  { id: 0, username: "DevMode", role: 'contractor' },
+          onSuccess:{screen:"Home"}
+        });
+     
     }
   
  

--- a/frontend/field-force-contractor/screens/SplashScreen.tsx
+++ b/frontend/field-force-contractor/screens/SplashScreen.tsx
@@ -30,7 +30,7 @@ import { AppContext }             from "@/contexts/AppContext";
 export const SplashScreen: FC = () => {
   const nav  = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { isLoading,isAuthenticated } = useAuth();
-  const {mount,setMounted} = useContext(AppContext);
+  const {mount,setMounted,devMode} = useContext(AppContext);
 
 
   // Prevents multiple navigations if the effect fires more than once
@@ -46,12 +46,18 @@ export const SplashScreen: FC = () => {
     if(!mount){
     setMounted(true);
     }
-
-    if (isAuthenticated) {
-      nav.replace('Home');
-    } else {
-      nav.replace('Login');
+    if(devMode === false){
+      if (isAuthenticated) {
+        nav.replace('Home');
+      } else {
+        nav.replace('Login');
+      }
     }
+    else{
+      nav.replace("Home");
+    }
+  
+ 
   }, SPLASH_TIME);
 
   return () => clearTimeout(timer);

--- a/frontend/field-force-contractor/screens/SplashScreen.tsx
+++ b/frontend/field-force-contractor/screens/SplashScreen.tsx
@@ -50,7 +50,7 @@ export const SplashScreen: FC = () => {
       if (isAuthenticated) {
         
         nav.replace('BiometricCheck',{
-          pendingToken: (token)? token : "",
+          pendingToken: token || "",
           pendingUser: { id: user?.id || 0, username: user?.username || "", role: user?.role || ""},
           onSuccess:{screen:"Home"}
         });

--- a/frontend/field-force-contractor/screens/SplashScreen.tsx
+++ b/frontend/field-force-contractor/screens/SplashScreen.tsx
@@ -29,7 +29,7 @@ import { AppContext }             from "@/contexts/AppContext";
 
 export const SplashScreen: FC = () => {
   const nav  = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-  const { isLoading,isAuthenticated } = useAuth();
+  const { isLoading,isAuthenticated,token,user } = useAuth();
   const {mount,setMounted,devMode} = useContext(AppContext);
 
 
@@ -50,8 +50,8 @@ export const SplashScreen: FC = () => {
       if (isAuthenticated) {
         
         nav.replace('BiometricCheck',{
-          pendingToken: 'dev-token',
-          pendingUser:  { id: 0, username: "DevMode", role: 'contractor' },
+          pendingToken: (token)? token : "",
+          pendingUser: { id: user?.id || 0, username: user?.username || "", role: user?.role || ""},
           onSuccess:{screen:"Home"}
         });
       } else {
@@ -60,8 +60,8 @@ export const SplashScreen: FC = () => {
     }
     else{
        nav.replace('BiometricCheck',{
-          pendingToken: 'dev-token',
-          pendingUser:  { id: 0, username: "DevMode", role: 'contractor' },
+          pendingToken:"dev-mode",
+          pendingUser: { id: 0, username:"Test", role:"vendor"},
           onSuccess:{screen:"Home"}
         });
      

--- a/frontend/field-force-contractor/utils/api.ts
+++ b/frontend/field-force-contractor/utils/api.ts
@@ -90,7 +90,7 @@ export function registerAuthFailureHandler(cb: () => void) { _onAuthFailure = cb
 const USE_DEPLOYED     = true;
 const DEPLOYED_API_URL = 'https://tr42-contractor.onrender.com';
 
-const LAN_IP = '10.0.0.152';            // ← your machine's Wi-Fi LAN IP (local dev only)
+const LAN_IP = '192.168.0.13';            // ← your machine's Wi-Fi LAN IP (local dev only)
 const PORT   = 5000;
 
 export const API_BASE_URL = USE_DEPLOYED


### PR DESCRIPTION
Team, in this update, I’ve introduced an onSuccess routing parameter for the BiometricCheck navigation. This resolves the issue where biometrics were not navigating to the appropriate page after successful validation. You can now specify the target screen (and optional parameters) after a successful check. When no onSuccess is provided, the flow safely returns.

Additionally, I added a dev mode to bypass the authentication check during development. This will help avoid server communication issues, allowing development to progress, but this mode will be disabled for production.

Changes were made in the BiometricCheck screen to inject the onSuccess parameter and handle it. A go function was added to navigate based on the onSuccess parameter. An OnSuccessRoute type was added to App.tsx to define the structure of the onSuccess parameter. I also configured the app to reuse the existing token when the app reloads if the user is already authenticated,, by passing it to BiometricCheck so that no new token is generated. Additionally, the onSuccess parameter was added to the BiometricCheck call within the login screen, allowing the app to navigate to the appropriate page after successful biometric verification. Additionally, the splash screen now triggers the BiometricCheck when the app starts. If the user is already authenticated, it requires biometric confirmation before returning to the account. If successful, it navigates the user to the home screen via the onSuccess parameter. otherwize to login to authenticate 