### PR TITLE
Updated the chat and messaging system to pull data from a global demo…

### DIFF
--- a/frontend/field-force-contractor/components/ContactCard.tsx
+++ b/frontend/field-force-contractor/components/ContactCard.tsx
@@ -5,18 +5,19 @@ import { useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import{RootStackParamList} from "@/App"
 import { ProfileIcon } from "./ProfileIcon";
+import { AppContext} from "@/contexts/AppContext";
 
-import {FC} from "react"
+import {FC, useContext} from "react"
 
 type Props = {
 
-    profileIcon?: string
     name?:string
     phoneNumber?: string
     contactId?: string
 }
 export const ContactCard:FC<Props> = (props) =>{
 const nav = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+
  const Call = (phone:string) =>{
 
     Linking.openURL(`tel:${phone}`)

--- a/frontend/field-force-contractor/components/Header.tsx
+++ b/frontend/field-force-contractor/components/Header.tsx
@@ -1,12 +1,13 @@
 import {Styles} from "@/constants/Styles"
 import {Assets} from "@/constants/Assets"
-import {FC} from "react"
+import {FC, useContext} from "react"
 import {View,Image, Pressable} from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/App"
 import { ProfileIcon } from "./ProfileIcon"
 export type HeaderVariant = 'default' | 'home' | "none"
+import { AppContext } from "@/contexts/AppContext"
 
 type Props ={
   
@@ -14,6 +15,7 @@ type Props ={
 }
 export const Header:FC<Props> = (props) =>{
   const nav = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
+  const {userInfo} = useContext(AppContext);
 
 // Header with just the logo and "Field Force" text
 const HeaderDefault: FC = () => (
@@ -31,7 +33,7 @@ const HeaderHome: FC = () => (
       <Image source={Assets.logos.ffLogoName} style={Styles.HeaderVariants.logo} resizeMode="contain" />
       <Pressable onPress={() => {nav.navigate("Profile")}}>
      
-      <ProfileIcon width={Styles.Menu.headMenuStyle2Icon.width} height={Styles.Menu.headMenuStyle2Icon.height} name="John Doe"/>
+      <ProfileIcon width={Styles.Menu.headMenuStyle2Icon.width} height={Styles.Menu.headMenuStyle2Icon.height} name={`${userInfo.firstName} ${userInfo.lastName}`}/>
       </Pressable>
       
     </View>

--- a/frontend/field-force-contractor/components/Message.tsx
+++ b/frontend/field-force-contractor/components/Message.tsx
@@ -1,43 +1,43 @@
 import{Assets} from "@/constants/Assets"
 import{Styles} from "@/constants/Styles"
-import{FC} from "react"
+import{FC, useContext} from "react"
 import {Text,View,Image} from "react-native"
 import { ProfileIcon } from "./ProfileIcon"
 import { TimeFormater } from "@/utils/timeFormater"
+import { AppContext } from "@/contexts/AppContext"
 
 export type MessageType = "sent" | "received"
 type Props = {
     message?:string
     messageId?:string
-    profileIcon?:string
-    contactId?:string
     contactName?:string
     senderId?:string
-    messageType?:string
-    timeStamp?:string
     utcTimeStamp?:string
 }
 export const Message:FC<Props> =(props) =>{
+  
+    const {userInfo} = useContext(AppContext);
    
+
     const Sent:FC = () => {
 
         return(
         
             <View style={Styles.Chat.messageBoxSent}>
-                    <Text style={Styles.Chat.timeText}>{props.timeStamp}</Text>
+                    <Text style={Styles.Chat.timeText}>{TimeFormater.getTimeStamp("LOCAL",props.utcTimeStamp)}</Text>
                 <View style={Styles.Chat.messageSent}>
                    
                     <Text style={Styles.Chat.messageText}>{props.message}</Text>
                 </View>
             
-                  <ProfileIcon width={Styles.Chat.chatIcon.width} height={Styles.Chat.chatIcon.height} name={props.contactName}/>
+                  <ProfileIcon width={Styles.Chat.chatIcon.width} height={Styles.Chat.chatIcon.height} name={`${userInfo.firstName} ${userInfo.lastName}`}/>
             </View>
 
         )
         
     }
     const Recieved:FC = () =>{
-
+ 
            return(
             <View style={Styles.Chat.messageBoxReceived}>   
                  <ProfileIcon width={Styles.Chat.chatIcon.width} height={Styles.Chat.chatIcon.height} name={props.contactName}/>
@@ -46,7 +46,7 @@ export const Message:FC<Props> =(props) =>{
                     
                     <Text style={Styles.Chat.messageText}>{props.message}</Text>
                 </View>
-                <Text style={Styles.Chat.timeText}>{props.timeStamp}</Text>
+                <Text style={Styles.Chat.timeText}>{TimeFormater.getTimeStamp("LOCAL",props.utcTimeStamp)}</Text>
             </View>
            )
 
@@ -54,7 +54,7 @@ export const Message:FC<Props> =(props) =>{
     return(<>
   
      {
-        (props.messageType === "sent") ? <Sent/> : <Recieved/>
+        (userInfo.userid === props.senderId) ? <Sent/> : <Recieved/>
      }
     
     </>)

--- a/frontend/field-force-contractor/contexts/AppContext.tsx
+++ b/frontend/field-force-contractor/contexts/AppContext.tsx
@@ -58,7 +58,7 @@ export const AppProvider = ({children} : {children:ReactNode}) =>{
    
     return(
 
-        <AppContext.Provider value={{mount,setMounted,reverseStack,setReverseStack,devMode,setDevMode,setUserInfo,userInfo,demoUsers}}>
+        <AppContext.Provider value={{mount,setMounted,reverseStack,setReverseStack,devMode,setDevMode,setUserInfo,userInfo}}>
         {children}
         </AppContext.Provider>
     )

--- a/frontend/field-force-contractor/contexts/AppContext.tsx
+++ b/frontend/field-force-contractor/contexts/AppContext.tsx
@@ -4,15 +4,61 @@ import { createContext,useState,ReactNode } from "react"
 
 export const  AppContext = createContext<any>(null)
 
+export type userTable = {
 
+    userid:string,
+    firstName:string,
+    lastName:string,
+    phone:string,
+    role:string
+}
+//Demo User Data
+export const demoUsers:userTable[] = [
+ {
+    userid:"0",
+    firstName:"John",
+    lastName:"Doe",
+    phone:"555-555-5555",
+    role:"contractor"
+ },
+ {
+    userid:"1",
+    firstName:"Jane",
+    lastName:"Doe",
+    phone:"666-555-5555",
+    role:"client"
+ },
+ {
+    userid:"2",
+    firstName:"Taylor",
+    lastName:"Swith",
+    phone:"777-555-5555",
+    role:"vendor"
+ },
+ {
+    userid:"3",
+    firstName:"Ben",
+    lastName:"Joe",
+    phone:"888-555-5555",
+    role:"contractor"
+ }
+
+]
+export const getUser = (userid:string) =>{
+
+    let user = demoUsers.find(p => p.userid === userid) || null
+  
+    return(user);
+}
 export const AppProvider = ({children} : {children:ReactNode}) =>{
    const [mount,setMounted] = useState(false);
    const [reverseStack,setReverseStack] = useState(false);
    const [devMode,setDevMode] = useState(false);
-  
+   const [userInfo,setUserInfo] = useState(getUser("1"));
+   
     return(
 
-        <AppContext.Provider value={{mount,setMounted,reverseStack,setReverseStack,devMode,setDevMode}}>
+        <AppContext.Provider value={{mount,setMounted,reverseStack,setReverseStack,devMode,setDevMode,setUserInfo,userInfo,demoUsers}}>
         {children}
         </AppContext.Provider>
     )

--- a/frontend/field-force-contractor/screens/ChatScreen.tsx
+++ b/frontend/field-force-contractor/screens/ChatScreen.tsx
@@ -10,21 +10,16 @@ import { TimeFormater } from "@/utils/timeFormater"
 import { useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/App"
-import { useAuth } from "@/contexts/AuthContext"
-import { AppContext } from "@/contexts/AppContext"
+import { AppContext,getUser} from "@/contexts/AppContext"
 
 type Props = {
 
     children:ReactNode
 }
 type TypeMessage = {
-
+    sessionId:string
     id:string
     message:string
-    contactId?:string
-    messageType:MessageType //Indicates if the mssage was sent or recieved so the app knows how to show it
-    timeStamp:string
-    contactName:string
     senderId:string
     utcTimeStamp:string
     
@@ -36,32 +31,68 @@ const FOOTER_MENU_HEIGHT = 110;
 const KEYBOARD_GAP = 8;
 
 
+//Demo Chat sessions database
+const demoSessions = [
+   {sessionid:"123456",
+    members: ["1","2"]
+   },
+   {sessionid:"1234567",
+    members: ["1","3"]
+   },
+   {sessionid:"12345678",
+    members: ["1","4"]
+   }
+]
+
+
+const createSession = (userA:string,userB:string) => {
+  //Checks the demo database to ensure that a message session does not already exist that contains the 2 contacts before creating a new one
+  let session;
+  if(demoSessions.some(p=> p.members.includes(userA) && p.members.includes(userB)) === false){
+    session = InitID.getId();
+    demoSessions.push({sessionid:session,members:[userA,userB]}) // create new session in demo database
+  }
+  else{
+   // if a session already exist for the 2 provided contacts return that message session id
+    session = demoSessions.find(p => p.members.includes(userA) && p.members.includes(userB))?.sessionid || ""
+  }
+ 
+ return(session);
+}
+ 
 export const Chat:FC = (props) =>{
+
 
     const route = useRoute<any>()
     const {name,contactId} = route.params
+
+    const {userInfo} = useContext(AppContext)
+    const sessionId = createSession(userInfo.userid || "",contactId)  
     const {height: windowHeight} = useWindowDimensions();
     const nav = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
-    const {user} = useAuth();
-    const CONTACTID = contactId;
-    const USERID = (user?.id || "").toString();
-    let USERSNAME = "John Doe" //Name should be replaced with users first + last name from the sql database
-    let CONTACTNAME = USERSNAME
-    const {reverseStack} = useContext(AppContext);
-    const demoMessages:TypeMessage[] = [ // Demo data real data will be replaced by backend
-    {id:InitID.getId(),message:"Hello",contactName:USERSNAME,contactId:CONTACTID,messageType:"sent",timeStamp:TimeFormater.getTimeStamp("LOCAL"),senderId:USERID?.toString(), utcTimeStamp:"2026-03-23T23:28:27.788Z"}, 
-    {id:InitID.getId(),message:"Hello",contactName:USERSNAME,contactId:CONTACTID,messageType:"sent",timeStamp:TimeFormater.getTimeStamp("LOCAL"),senderId:USERID?.toString(), utcTimeStamp:"2026-03-23T23:28:27.788Z"}, 
-    {id:InitID.getId(),message:"Hello",contactName:USERSNAME,contactId:CONTACTID,messageType:"sent",timeStamp:TimeFormater.getTimeStamp("LOCAL"),senderId:USERID?.toString(), utcTimeStamp:"2026-03-24T23:28:27.788Z"}, 
-    {id:InitID.getId(),message:"Hi",contactName:name, contactId:USERID?.toString(),messageType:"received",timeStamp:TimeFormater.getTimeStamp("LOCAL"),senderId:CONTACTID,utcTimeStamp:TimeFormater.getTimeStamp("UTC-DATE")},
-    {id:InitID.getId(),message:"How are you doing?",contactName:USERSNAME, contactId:CONTACTID,messageType:"sent",timeStamp:TimeFormater.getTimeStamp("LOCAL"),senderId:USERID?.toString(), utcTimeStamp:TimeFormater.getTimeStamp("UTC-DATE")}, 
+   
+   
+    let contactuser = getUser(contactId);
+    let CONTACTNAME = `${contactuser?.firstName} ${contactuser?.lastName}`
+
+
+      //Demo Messages database 
+    const demoMessages:TypeMessage[] = [
+    {sessionId:sessionId, id:InitID.getId(),message:"Hello",senderId:userInfo.userid, utcTimeStamp:"2026-03-23T23:28:27.788Z"}, 
+    {sessionId:sessionId,id:InitID.getId(),message:"Hello",senderId:contactId, utcTimeStamp:"2026-03-23T23:28:27.788Z"}, 
+    {sessionId:sessionId, id:InitID.getId(),message:"Hello",senderId:userInfo.userid, utcTimeStamp:"2026-03-24T23:28:27.788Z"}, 
+    {sessionId:sessionId,id:InitID.getId(),message:"Hi",senderId:contactId,utcTimeStamp:TimeFormater.getTimeStamp("UTC-DATE")},
+    {sessionId:sessionId,id:InitID.getId(),message:"How are you doing?",senderId:userInfo.userid, utcTimeStamp:TimeFormater.getTimeStamp("UTC-DATE")}, 
     ]
    
+    const {reverseStack} = useContext(AppContext);
     const [messages,setMessage] = useState(demoMessages);
     const scrollRef = useRef<ScrollView>(null);
-
     const [send,setSend] = useState<MessageType>("received");
     const [searchBarBottom,setSearchBarBottom] = useState(FOOTER_MENU_HEIGHT);
-    
+
+  
+
     useEffect(() => {
         const showSubscription = Keyboard.addListener(
             Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow",
@@ -84,31 +115,26 @@ export const Chat:FC = (props) =>{
     }, [windowHeight]);
   
    
-    const SendMessage = (mesg:string,contact:string,contactId:string) =>{
+    const SendMessage = (mesg:string) =>{
         let sendersid;
-        let contactsid;
+        
         if(send === "sent"){ //Testing Data will be removed in production 
 
             setSend("received");
-            sendersid = CONTACTID
-            contactsid = USERID
-            CONTACTNAME = USERSNAME
+            sendersid = contactId
+          
         }
         else{
 
             setSend("sent");
-            sendersid = USERID
-            contactsid = CONTACTID
-            CONTACTNAME = name
+            sendersid = userInfo.userid
+          
         }
 
         setMessage(prev => [...prev,{
+            sessionId:sessionId,
             id:InitID.getId(),
             message:mesg,
-            contactid:contactsid, //This should be replaced with the contactId paramater provided in SendMessage()
-            contactName:CONTACTNAME,
-            messageType:send,
-            timeStamp: TimeFormater.getTimeStamp("LOCAL"),
             senderId: sendersid,
             utcTimeStamp:TimeFormater.getTimeStamp("UTC-DATE")
         }]);
@@ -143,7 +169,7 @@ export const Chat:FC = (props) =>{
                     
                 { (setLabel !== "" && <Text style={Styles.Chat.dateMarker}>{setLabel}</Text>)}
                     
-                <Message messageId={item.id} message={item.message} contactName={item.contactName} contactId={item.contactId} senderId={item.senderId} messageType={item.messageType} timeStamp={item.timeStamp} utcTimeStamp={item.utcTimeStamp}></Message>
+                <Message messageId={item.id} message={item.message} senderId={item.senderId} utcTimeStamp={item.utcTimeStamp} contactName={CONTACTNAME || ""}></Message>
                 </React.Fragment>
       )})
 
@@ -165,7 +191,7 @@ export const Chat:FC = (props) =>{
           </ScrollView>
     </MainFrame>
     <View style={[Styles.Chat.sendBar, {bottom: searchBarBottom}]}>
-        <SearchBar placeHolder="Message..." buttonText="Send" multiline onClick={(msg:string)=>{(msg) && SendMessage(msg,CONTACTNAME,CONTACTID)}} resetOnSubmit={true}/>
+        <SearchBar placeHolder="Message..." buttonText="Send" multiline onClick={(msg:string)=>{(msg) && SendMessage(msg)}} resetOnSubmit={true}/>
     </View>
     </View>
 

--- a/frontend/field-force-contractor/screens/ContactScreen.tsx
+++ b/frontend/field-force-contractor/screens/ContactScreen.tsx
@@ -5,19 +5,14 @@ import { ContactCard } from "@/components/ContactCard"
 import { useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from "@/App"
-import { InitID } from "@/utils/InitID"
+import { demoUsers } from "@/contexts/AppContext"
 
 
 export const Contacts:FC = (props) => {
     
-    const contactData = [ //PlaceHolder Contact Data  will be provided by backend
-        {id:InitID.getId(),name:"John Doe",phone:"555-555-5555"}, // ids need to be replaced with data from database 
-        {id:InitID.getId(),name:"Jane Doe", phone:"444-444-4444"},
-        {id:InitID.getId(),name:"Taylor Swift",phone:"555-555-5555"}
-
-    ]
+ 
     const nav = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
-    const [contacts] = useState(contactData)
+    const [contacts] = useState(demoUsers)
     const  [nameSearch,setNameSearch] = useState("");
     const Search:FC = () =>{
        return(
@@ -28,8 +23,8 @@ export const Contacts:FC = (props) => {
     <MainFrame header="home" headerMenu={["Menu2",["Contacts"]]} injectHeader={<Search/>}>
     
       {
-        contacts.filter(ct => ct.name.toUpperCase().includes(nameSearch.toUpperCase())).map((item) =>{
-          return( <ContactCard key={item.id} contactId={item.id} phoneNumber={item.phone} name={item.name}/>)
+        contacts.filter(ct => (`${ct.firstName.toUpperCase()} ${ct.lastName.toUpperCase()}`).includes(nameSearch.toUpperCase())).map((item) =>{
+          return( <ContactCard key={item.userid} contactId={item.userid} phoneNumber={item.phone} name={`${item.firstName} ${ item.lastName}`}/>)
         })
       }
     

--- a/frontend/field-force-contractor/screens/SplashScreen.tsx
+++ b/frontend/field-force-contractor/screens/SplashScreen.tsx
@@ -30,7 +30,7 @@ import { AppContext }             from "@/contexts/AppContext";
 export const SplashScreen: FC = () => {
   const nav  = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { isLoading,isAuthenticated,token,user } = useAuth();
-  const {mount,setMounted,devMode} = useContext(AppContext);
+  const {mount,setMounted,devMode,setUserInfo} = useContext(AppContext);
 
 
   // Prevents multiple navigations if the effect fires more than once


### PR DESCRIPTION
 This PR updates the chat and messaging demo flow to use a shared global demo user source from `AppContext` instead of duplicating user/contact data across chat, contacts, headers, and message rendering.

The main goal is to simplify the messaging data model, centralize demo user information, and make chat/contact UI behavior more consistent with how backend-backed user records will eventually work.

Changes Added

- Added a global demo user table in `AppContext`
  - Introduces a `userTable` type.
  - Adds `demoUsers` with user id, first name, last name, phone, and role.
  - Adds `getUser(userid)` helper for looking up a user by id.
  - Adds global `userInfo` state initialized to demo user `1`.
  - Exposes `userInfo`, `setUserInfo`, and `demoUsers` through `AppContext`.

- Updated Contacts screen to use global demo users
  - Replaces locally generated placeholder contact data with `demoUsers`.
  - Uses `userid` as the contact id.
  - Builds display names from `firstName + lastName`.
  - Updates contact search to filter against the new user table structure.

- Updated Chat screen message structure
  - Adds session-based demo chat data.
  - Adds `createSession(userA, userB)` to reuse an existing session between two users or create one when needed.
  - Simplifies each message object to include:
    - `sessionId`
    - `id`
    - `message`
    - `senderId`
    - `utcTimeStamp`
  - Removes duplicated per-message fields like `contactName`, `contactId`, `messageType`, and local `timeStamp`.
  - Uses global `userInfo.userid` and the selected contact id to determine who sent each message.
  - Keeps existing date marker and reverse order behavior.

- Updated Message component rendering
  - Message direction is now inferred by comparing `senderId` to `userInfo.userid`.
  - Local display time is derived from `utcTimeStamp` using `TimeFormater`.
  - Sent messages now show the current global user’s profile icon name.
  - Received messages continue to show the contact profile icon.

- Updated Header profile icon
  - Replaces hardcoded `"John Doe"` with the current global user from `AppContext`.

- Updated ContactCard navigation data
  - Continues to route to `Chat`, now passing the global user-table contact id.

- Updated SplashScreen context access
  - Pulls `setUserInfo` from `AppContext`, preparing the splash/auth flow to support setting the active global user.

## Why This Was Implemented

Previously, chat and contact data was duplicated in multiple places and each message carried fields that could be derived from shared user/session data. This made the demo chat flow harder to maintain and less aligned with how backend-backed messaging data will likely be structured.

This change centralizes user data in `AppContext`, allowing contacts, headers, profile icons, and chat messages to reference the same source of truth. It also simplifies message objects so they more closely resemble persisted chat records: a message belongs to a session, has a sender, contains text, and stores a UTC timestamp.

This should make the current demo implementation easier to extend when real backend user/contact/message data is connected.

