### PR TITLE
fix(inspections): accept string template_id and item_id

### DIFF
--- a/backend/app/blueprints/inspections/schemas.py
+++ b/backend/app/blueprints/inspections/schemas.py
@@ -45,7 +45,7 @@ class InspectionSchema(ma.SQLAlchemyAutoSchema):
 
 class ItemResultInputSchema(Schema):
     """One item result inside a submission."""
-    item_id = fields.Int(required=True)
+    item_id = fields.Str(required=True)
     passed = fields.Bool(required=True)
     note = fields.Str(required=False, load_default=None)
 
@@ -59,7 +59,7 @@ class InspectionSubmitSchema(Schema):
                               still see who bypassed the inspection.
     - Otherwise             → per-item results[] must be provided.
     """
-    template_id = fields.Int(required=True)
+    template_id = fields.Str(required=True)
     no_issues_found = fields.Bool(required=False, load_default=False)
     skipped = fields.Bool(required=False, load_default=False)
     results = fields.List(fields.Nested(ItemResultInputSchema), required=False, load_default=[])


### PR DESCRIPTION
## Summary

Hotfix: inspection submit returns 400 because the marshmallow schema still
validates `template_id` and `item_id` as `fields.Int`, but the inspection PKs
moved to text/UUID when the models were synced to the team Supabase schema (in
#217). Frontend posts the string ids it got back from `/inspections/checklist`,
marshmallow rejects, contractor sees "Request failed with status 400" on
Submit Inspection / No Issues Found.

## Change

`backend/app/blueprints/inspections/schemas.py`:

- `ItemResultInputSchema.item_id`: `fields.Int` → `fields.Str`
- `InspectionSubmitSchema.template_id`: `fields.Int` → `fields.Str`

The route hands these values to `db.session.get(InspectionTemplates, ...)` and
`db.session.get(InspectionItems, ...)` unchanged, and both models expect
strings, so no other changes needed.

## Test plan

- [ ] Login as `demo` / `demo123` against deployed backend
- [ ] Open the app, hit the Inspection Required gate on cold start
- [ ] Tap "No Issues Found" → submission succeeds, returns 201
- [ ] Tap individual checklist items, then "Submit Inspection" → submission succeeds