### PR TITLE
fix(analytics): resolve contractor.id from request.user_id

### DIFF
--- a/backend/app/blueprints/analytics/routes.py
+++ b/backend/app/blueprints/analytics/routes.py
@@ -41,20 +41,37 @@ from . import analytics_bp
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 def _resolve_contractor_id():
-    """Return (contractor_id, error_response). Default to token owner.
+    """Return (contractor_id, error_response).
+
+    The token gives us `request.user_id` which is the auth_user.id. Tickets,
+    notifications, and contractor_performance rows all reference contractor.id
+    (a separate UUID), not auth_user.id, so we look up the contractor row via
+    its `user_id` FK first and return that row's id.
 
     Vendors can pass ?contractor_id=<id> to read another contractor's stats.
     Contractors can only read their own.
     """
+    # Look up the caller's own contractor.id (separate UUID from auth_user.id)
+    own_row = db.session.execute(
+        text("SELECT id FROM contractor WHERE user_id = :uid LIMIT 1"),
+        {'uid': request.user_id},
+    ).first()
+    if not own_row:
+        return None, (
+            jsonify({'error': 'No contractor record associated with this account'}),
+            403,
+        )
+    own_contractor_id = own_row[0]
+
     raw = (request.args.get('contractor_id') or '').strip()
     if not raw:
-        return request.user_id, None
+        return own_contractor_id, None
 
     role = (getattr(request, 'user_role', '') or '').lower()
     if role == 'vendor':
         return raw, None
 
-    if raw != request.user_id:
+    if raw != own_contractor_id:
         return None, (
             jsonify({'error': 'Forbidden: you may only access your own analytics'}),
             403,
@@ -346,7 +363,7 @@ def get_contractor_profile():
             c.years_experience,
             c.created_at
         FROM contractor c
-        JOIN auth_user au ON au.id = c.id
+        JOIN auth_user au ON au.id = c.user_id
         WHERE c.id = :cid
         """,
         params,
@@ -412,20 +429,22 @@ def get_contractor_profile():
 @analytics_bp.route('/notifications', methods=['GET'])
 @token_required
 def get_notifications():
-    """Recent notifications addressed to this user."""
-    contractor_id, err = _resolve_contractor_id()
-    if err:
-        return err
+    """Recent notifications addressed to this user.
 
+    `notification.recipient` stores `auth_user.id`, not `contractor.id`, so
+    this endpoint matches against `request.user_id` directly without going
+    through the contractor lookup. Verified against the live DB: 100% of
+    rows match auth_user.id, 0% match contractor.id.
+    """
     rows, qerr = _execute_query(
         """
         SELECT id, message, level, created_at
         FROM notification
-        WHERE recipient = :cid
+        WHERE recipient = :uid
         ORDER BY created_at DESC
         LIMIT 20
         """,
-        {'cid': contractor_id},
+        {'uid': request.user_id},
     )
     if qerr:
         return jsonify({'error': f'notifications query failed: {qerr}'}), 500


### PR DESCRIPTION
## Summary

Hotfix on top of #208. The analytics queries filtered by request.user_id directly, but `ticket.assigned_contractor` and `contractor_performance.contractor_id` both reference `contractor.id` (a separate UUID), not `auth_user.id`. Result: every endpoint returned empty zeros for the demo contractor and `/profile` returned 404.

## Change

\`_resolve_contractor_id()\` now does the standard pattern (mirrors \`field_contractors/routes.py:184-186\`): look up the contractor row via \`contractor.user_id = request.user_id\` and return that row's \`id\`. Adds one indexed query per request.

\`/profile\` JOIN flipped from \`au.id = c.id\` to \`au.id = c.user_id\`.

\`/notifications\` keys on \`request.user_id\` directly since \`notification.recipient\` stores \`auth_user.id\` (verified against the live DB: 100% of rows match auth_user.id, 0% match contractor.id).

## Test plan

- [x] Smoke against deployed Render: all 7 analytics endpoints return 200 with real data
- [ ] Phone test: dashboard stats card shows real numbers for demo contractor