### PR TITLE
feat(profile): license expiration banner on Profile screen

### DIFF
--- a/backend/app/blueprints/field_contractors/routes.py
+++ b/backend/app/blueprints/field_contractors/routes.py
@@ -1,5 +1,5 @@
 from flask import request, jsonify
-from app.models import AuthUser, Contractor, Ticket, Address, db
+from app.models import AuthUser, Contractor, Ticket, Address, License, db
 from .schemas import contractor_register_schema, contractor_schema, contractor_update_schema
 from ..auth_users.schemas import auth_user_update_schema, auth_user_create_schema
 from ..tickets.schemas import tickets_schema
@@ -7,7 +7,7 @@ from marshmallow import ValidationError
 from werkzeug.security import generate_password_hash, check_password_hash
 from . import field_contractors_bp
 from app.util.auth import encode_token, token_required, vendor_required
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 
 #Register contractor (for testing, delete later)
@@ -187,3 +187,45 @@ def get_assigned_tickets():
         return tickets_schema.jsonify(tickets), 200
     except Exception as e:
         return jsonify({'error': 'Failed to retrieve tickets'}), 500
+
+
+# ── Licenses for the authenticated contractor ───────────────────────────────
+# Used by the Profile screen to render the license expiration banner.
+# Returns each license with a computed `days_until_expiration` so the frontend
+# doesn't have to do date math (negative values mean expired N days ago).
+# Sorted soonest expiration first so the most urgent shows at the top.
+@field_contractors_bp.route('/me/licenses', methods=['GET'])
+@token_required
+def get_my_licenses():
+    contractor = (
+        db.session
+        .query(Contractor)
+        .filter(Contractor.user_id == request.user_id)
+        .first()
+    )
+    if not contractor:
+        return jsonify({'error': 'No contractor record for this user'}), 404
+
+    licenses = (
+        db.session
+        .query(License)
+        .filter(License.contractor_id == contractor.id)
+        .order_by(License.license_expiration_date.asc())
+        .all()
+    )
+
+    today = date.today()
+    payload = [
+        {
+            'id':                       l.id,
+            'license_type':             l.license_type,
+            'license_number':           l.license_number,
+            'license_state':            l.license_state,
+            'license_expiration_date':  l.license_expiration_date.isoformat() if l.license_expiration_date else None,
+            'license_verified':         l.license_verified,
+            'days_until_expiration':    (l.license_expiration_date - today).days if l.license_expiration_date else None,
+        }
+        for l in licenses
+    ]
+
+    return jsonify({'licenses': payload, 'count': len(payload)}), 200

--- a/frontend/field-force-contractor/components/LicenseExpirationBanner.tsx
+++ b/frontend/field-force-contractor/components/LicenseExpirationBanner.tsx
@@ -1,0 +1,199 @@
+// LicenseExpirationBanner.tsx
+// Profile screen banner that surfaces licenses about to expire (or already
+// expired). Cory called this out as a stakeholder priority — a contractor
+// should see it the moment they open the Profile tab.
+//
+// Severity rules:
+//   ≤  7 days  or already expired → red    (CRITICAL)
+//   ≤ 30 days                     → amber  (WARNING)
+//   ≤ 60 days                     → yellow (HEADS UP)
+//   > 60 days                     → not rendered (no banner shown)
+//
+// If multiple licenses qualify, we show the most urgent one in the headline
+// and a "+N more" pill for the rest. Tapping the banner navigates to the
+// full LicenseDetails screen.
+
+import { FC, useEffect, useState } from 'react'
+import { Text, TouchableOpacity, View, StyleSheet, ActivityIndicator } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { useNavigation } from '@react-navigation/native'
+import { NativeStackNavigationProp } from '@react-navigation/native-stack'
+
+import { RootStackParamList } from '@/App'
+import { api } from '@/utils/api'
+
+type Nav = NativeStackNavigationProp<RootStackParamList>
+
+interface LicenseRow {
+    id: string
+    license_type: string
+    license_number: string
+    license_state: string
+    license_expiration_date: string | null
+    license_verified: boolean | null
+    days_until_expiration: number | null
+}
+
+interface LicensesResponse {
+    licenses: LicenseRow[]
+    count: number
+}
+
+// ── Severity classification ────────────────────────────────────────────────
+
+type Severity = 'critical' | 'warning' | 'heads-up'
+
+function severityFor(days: number | null): Severity | null {
+    if (days == null) return null
+    if (days <= 7)  return 'critical'   // expired or expiring this week
+    if (days <= 30) return 'warning'    // within a month
+    if (days <= 60) return 'heads-up'   // within two months
+    return null                          // healthy, no banner
+}
+
+const SEVERITY_STYLE: Record<Severity, {
+    bg: string
+    border: string
+    fg: string
+    icon: keyof typeof Ionicons.glyphMap
+    label: string
+}> = {
+    critical: {
+        bg:     'rgba(239,68,68,0.12)',
+        border: 'rgba(239,68,68,0.45)',
+        fg:     '#ef4444',
+        icon:   'alert-circle',
+        label:  'CRITICAL',
+    },
+    warning: {
+        bg:     'rgba(245,158,11,0.12)',
+        border: 'rgba(245,158,11,0.45)',
+        fg:     '#f59e0b',
+        icon:   'warning',
+        label:  'WARNING',
+    },
+    'heads-up': {
+        bg:     'rgba(250,204,21,0.10)',
+        border: 'rgba(250,204,21,0.40)',
+        fg:     '#facc15',
+        icon:   'time',
+        label:  'HEADS UP',
+    },
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function describeDays(days: number): string {
+    if (days < 0)  return `expired ${Math.abs(days)} day${Math.abs(days) === 1 ? '' : 's'} ago`
+    if (days === 0) return 'expires today'
+    if (days === 1) return 'expires tomorrow'
+    return `expires in ${days} days`
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export const LicenseExpirationBanner: FC = () => {
+    const navigation = useNavigation<Nav>()
+    const [loading,  setLoading]  = useState(true)
+    const [licenses, setLicenses] = useState<LicenseRow[]>([])
+
+    useEffect(() => {
+        let cancelled = false
+        api.authGet<LicensesResponse>('/contractors/me/licenses')
+            .then(res => { if (!cancelled) setLicenses(res.licenses) })
+            .catch(() => { if (!cancelled) setLicenses([]) })
+            .finally(() => { if (!cancelled) setLoading(false) })
+        return () => { cancelled = true }
+    }, [])
+
+    if (loading) {
+        // Subtle placeholder so the layout doesn't jump when the banner finally
+        // renders. Hidden once data lands.
+        return (
+            <View style={[s.banner, s.placeholder]}>
+                <ActivityIndicator size="small" color="rgba(255,255,255,0.4)" />
+            </View>
+        )
+    }
+
+    // Filter to only licenses that should trigger a banner, then pick the most
+    // urgent one (lowest days_until_expiration).
+    const flagged = licenses
+        .map(l => ({ row: l, severity: severityFor(l.days_until_expiration) }))
+        .filter((x): x is { row: LicenseRow; severity: Severity } => x.severity !== null)
+        .sort((a, b) => (a.row.days_until_expiration ?? 0) - (b.row.days_until_expiration ?? 0))
+
+    if (flagged.length === 0) return null
+
+    const top  = flagged[0]
+    const rest = flagged.length - 1
+    const sev  = SEVERITY_STYLE[top.severity]
+
+    return (
+        <TouchableOpacity
+            style={[s.banner, { backgroundColor: sev.bg, borderColor: sev.border }]}
+            onPress={() => navigation.navigate('LicenseDetails')}
+            activeOpacity={0.8}
+        >
+            <View style={[s.iconWrap, { backgroundColor: sev.fg }]}>
+                <Ionicons name={sev.icon} size={18} color="#0a0a0a" />
+            </View>
+            <View style={{ flex: 1 }}>
+                <Text style={[s.severityLabel, { color: sev.fg }]}>{sev.label}</Text>
+                <Text style={s.title} numberOfLines={1}>{top.row.license_type}</Text>
+                <Text style={s.subtitle} numberOfLines={1}>
+                    {describeDays(top.row.days_until_expiration ?? 0)}
+                    {rest > 0 ? ` · +${rest} more flagged` : ''}
+                </Text>
+            </View>
+            <Ionicons name="chevron-forward" size={18} color={sev.fg} />
+        </TouchableOpacity>
+    )
+}
+
+// ── Styles ─────────────────────────────────────────────────────────────────
+
+const s = StyleSheet.create({
+    banner: {
+        flexDirection:    'row',
+        alignItems:       'center',
+        gap:              12,
+        padding:          14,
+        borderRadius:     14,
+        borderWidth:      1,
+        marginHorizontal: 16,
+        marginTop:        12,
+    },
+    placeholder: {
+        backgroundColor: 'rgba(255,255,255,0.03)',
+        borderColor:     'rgba(255,255,255,0.08)',
+        height:          64,
+        justifyContent:  'center',
+    },
+    iconWrap: {
+        width:          36,
+        height:         36,
+        borderRadius:   18,
+        alignItems:     'center',
+        justifyContent: 'center',
+    },
+    severityLabel: {
+        fontFamily:    'poppins-bold',
+        fontSize:      10,
+        letterSpacing: 0.6,
+    },
+    title: {
+        fontFamily: 'poppins-bold',
+        fontSize:   14,
+        color:      '#fff',
+        marginTop:  2,
+    },
+    subtitle: {
+        fontFamily: 'poppins-regular',
+        fontSize:   12,
+        color:      'rgba(255,255,255,0.65)',
+        marginTop:  2,
+    },
+})
+
+export default LicenseExpirationBanner

--- a/frontend/field-force-contractor/screens/ProfileScreen.tsx
+++ b/frontend/field-force-contractor/screens/ProfileScreen.tsx
@@ -29,6 +29,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { RootStackParamList } from '../App';
 import { MainFrame } from '../components/MainFrame';
+import { LicenseExpirationBanner } from '../components/LicenseExpirationBanner';
 
 import { useTheme }           from '../contexts/ThemeContext';
 import { spacing, radius, fontSize, fonts } from '../constants/theme';
@@ -158,6 +159,11 @@ export default function ProfileScreen() {
         backgroundColor="transparent"
         translucent
       />
+
+      {/* ── License expiration banner (Cory stakeholder ask) ─── */}
+      {/* Renders only when at least one license is within 60 days of expiry
+          or already expired. Tapping navigates to the LicenseDetails screen. */}
+      <LicenseExpirationBanner />
 
       {/* ── Avatar + name ─────────────────────────────── */}
       <View style={[styles.avatarBlock, { backgroundColor: lightMode ? '#dde6f0' : '#0f1d33' }]}>


### PR DESCRIPTION
## Summary

Closes Cory's stakeholder ask from 3/31: "showing alerts such as exceeded drive time or license expiration warnings."

## What lands

**Backend**
- New endpoint `GET /contractors/me/licenses` returns the authenticated contractor's licenses with a computed `days_until_expiration` field. Negative values mean expired N days ago. Sorted soonest expiration first.

**Frontend**
- New `LicenseExpirationBanner` component on `ProfileScreen` (above the avatar block). Color-coded by severity:
  - **CRITICAL** (red): expired or expiring within 7 days
  - **WARNING** (amber): within 30 days
  - **HEADS UP** (yellow): within 60 days
  - No banner renders when all licenses are >60 days out (UI stays quiet for compliant contractors)
- Banner shows the most urgent license + "+N more flagged" pill when multiple need attention
- Tap to navigate to `LicenseDetails` for the full list

## Demo data seeded

Three license rows in team Supabase for the demo contractor (`dd2a72e2-d8ec-4d57-9a0b-ffba8e886d46`):
- OSHA 30 Construction Safety, expires in 5 days (drives the CRITICAL banner)
- CDL Class A, expires in 25 days
- Hazmat Endorsement, expires in 75 days (won't trigger banner, just lives in the LicenseDetails list)

## Test plan

- [x] `GET /contractors/me/licenses` returns 200 with the demo licenses + computed days_until_expiration
- [ ] Login as `demo` / `demo123` against deployed backend
- [ ] Open Profile tab → CRITICAL red banner shows "OSHA 30 Construction Safety" + "expires in 5 days · +1 more flagged"
- [ ] Tap banner → navigates to LicenseDetails screen
- [ ] When all licenses are >60 days out, banner is hidden entirely

## Cory's ask

> 3/31 meeting: "Cory mentions he would like showing alerts such as: exceeded drive time or license expiration warnings."

This PR addresses the license expiration half. Drive time alerts (color-coded bottom bar) are tracked separately.