### PR TITLE
feat(ai): voice dictation on Field Force AI screen

### DIFF
--- a/frontend/field-force-contractor/screens/InspectionAssistScreen.tsx
+++ b/frontend/field-force-contractor/screens/InspectionAssistScreen.tsx
@@ -5,6 +5,7 @@
 
 import { FC, useEffect, useRef, useState } from 'react'
 import {
+    Alert,
     Animated,
     KeyboardAvoidingView,
     Modal,
@@ -17,6 +18,24 @@ import {
     View,
 } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
+
+// ─── Speech recognition shim ─────────────────────────────────────────────────
+// expo-speech-recognition is a custom native module not bundled in Expo Go.
+// Mirrors the shim pattern in TicketDetailScreen so this screen still mounts
+// when running under Expo Go — voice dictation just becomes inactive.
+let ExpoSpeechRecognitionModule: any = {
+    stop: () => {},
+    start: (_opts?: any) => {},
+    requestPermissionsAsync: async () => ({ granted: false }),
+}
+let useSpeechRecognitionEvent: any = (_event: string, _handler: any) => {}
+try {
+    const m = require('expo-speech-recognition')
+    ExpoSpeechRecognitionModule = m.ExpoSpeechRecognitionModule
+    useSpeechRecognitionEvent    = m.useSpeechRecognitionEvent
+} catch {
+    // running in Expo Go, voice dictation disabled
+}
 import { useNavigation } from '@react-navigation/native'
 import { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import { MainFrame } from '@/components/MainFrame'
@@ -216,12 +235,46 @@ export const InspectionAssistScreen: FC = () => {
     const [suggestionsVisible, setSuggestions] = useState(true)
     const [refineMsgId, setRefineMsgId]        = useState<string | null>(null)
     const [refineFeedback, setRefineFeedback]  = useState('')
+    const [listening, setListening]            = useState(false)
     const scrollRef                            = useRef<ScrollView>(null)
     const abortRef                             = useRef<(() => void) | null>(null)
 
     // Cancel any in-flight stream on unmount so the user can navigate away
     // without leaving the request hanging.
     useEffect(() => () => { abortRef.current?.() }, [])
+
+    // Voice dictation hooks (Cory's stakeholder ask: "Report/task auto-fill
+    // by voice — contractor dictates, AI populates task fields"). The
+    // transcript is fed straight into handleSend so the AI structures the
+    // dictation into a report exactly like a typed message would.
+    useSpeechRecognitionEvent('start', () => setListening(true))
+    useSpeechRecognitionEvent('end',   () => setListening(false))
+    useSpeechRecognitionEvent('result', (event: any) => {
+        const transcript = event?.results?.[0]?.transcript
+        if (transcript && transcript.trim()) {
+            handleSend(transcript.trim())
+        }
+    })
+    useSpeechRecognitionEvent('error', (event: any) => {
+        console.warn('Speech error:', event?.error, event?.message)
+        setListening(false)
+    })
+
+    const toggleVoice = async () => {
+        if (listening) {
+            ExpoSpeechRecognitionModule.stop()
+            return
+        }
+        const { granted } = await ExpoSpeechRecognitionModule.requestPermissionsAsync()
+        if (!granted) {
+            Alert.alert(
+                'Microphone needed',
+                'Allow microphone and speech recognition access to dictate inspection reports.',
+            )
+            return
+        }
+        ExpoSpeechRecognitionModule.start({ lang: 'en-US', continuous: false })
+    }
 
     const scroll = () => setTimeout(() => scrollRef.current?.scrollToEnd({ animated: true }), 80)
 
@@ -377,6 +430,25 @@ export const InspectionAssistScreen: FC = () => {
                         <Ionicons name="folder-open-outline" size={16} color="#a78bfa" />
                         <Text style={s.savedReportsBtnText}>View Saved Reports</Text>
                         <Ionicons name="chevron-forward" size={14} color="rgba(167,139,250,0.6)" style={{ marginLeft: 'auto' }} />
+                    </TouchableOpacity>
+
+                    {/* ── Voice dictation chip (Cory ask: hands-free reporting) ──
+                        Always visible, even after the conversation starts, so
+                        contractors can keep dictating new reports throughout
+                        a session. */}
+                    <TouchableOpacity
+                        style={[s.chip, s.voiceChip, listening && s.voiceChipActive]}
+                        onPress={toggleVoice}
+                        activeOpacity={0.7}
+                    >
+                        <Ionicons
+                            name={listening ? 'stop-circle' : 'mic'}
+                            size={14}
+                            color={listening ? '#0a0a0a' : '#34d399'}
+                        />
+                        <Text style={[s.chipText, s.voiceChipText, listening && s.voiceChipTextActive]}>
+                            {listening ? 'Listening... tap to stop' : 'Speak instead of typing'}
+                        </Text>
                     </TouchableOpacity>
 
                     {/* ── Suggestion chips ── */}
@@ -561,6 +633,26 @@ const s = StyleSheet.create({
         fontFamily: 'poppins-regular',
         fontSize:   13,
         color:      '#a78bfa',
+    },
+
+    // Voice chip — green to differentiate from purple suggestion chips,
+    // flips to a solid green when actively listening so the contractor
+    // sees the recording state at a glance.
+    voiceChip: {
+        backgroundColor: 'rgba(52,211,153,0.08)',
+        borderColor:     'rgba(52,211,153,0.30)',
+        marginBottom:    8,
+    },
+    voiceChipActive: {
+        backgroundColor: '#34d399',
+        borderColor:     '#34d399',
+    },
+    voiceChipText: {
+        color: '#34d399',
+    },
+    voiceChipTextActive: {
+        color:     '#0a0a0a',
+        fontFamily: 'poppins-bold',
     },
 
     // Divider


### PR DESCRIPTION
## Summary

Closes Cory's stakeholder ask from the 4/27 meeting: "Report/task auto-fill by voice: contractor dictates, AI populates task fields."

## What lands

- `expo-speech-recognition` shim added (mirrors the pattern in `TicketDetailScreen`) so the screen still mounts under Expo Go where the native module isn't bundled.
- New **"Speak instead of typing"** chip on `InspectionAssistScreen`, always visible above the existing suggestion chips. Tap to start dictation, tap again to stop.
- Visual state flips the chip green-on-dark and updates the label while listening.
- On transcript, the text is fed straight into `handleSend()` so the AI streams a structured inspection report. No new code path — voice dictation goes through the same `/api/ai/inspection-assist/stream` route as typed messages.

## Demo flow

1. Open Field Force AI
2. Tap the green Speak chip
3. Say: "We saw a leaking valve at well 7, sparking near the panel, smelled like gas"
4. AI streams a structured report with priority, category, description, recommended actions

## Backend

Untouched. AI inspection-assist already handles arbitrary natural-language input — voice just adds a new way to get the input there.