### PR TITLE
feat(proximity): tighten start-task threshold to 100ft

### DIFF
--- a/frontend/field-force-contractor/screens/TicketDetailScreen.tsx
+++ b/frontend/field-force-contractor/screens/TicketDetailScreen.tsx
@@ -94,10 +94,19 @@ export default function TicketDetailScreen() {
             task.locationCoords.lat,
             task.locationCoords.lng
           );
-          const METERS_PER_MILE = 1609; // ~1 mile
-          const THRESHOLD_METERS = METERS_PER_MILE;
+          // Cory's stakeholder ask (3/24): "within 100 ft he wants bio
+          // authentication when arriving and leaving. He likes the
+          // simplicity of it." Tightening the start-task proximity check to
+          // 100ft as a first step. Full geofence-triggered biometric
+          // (fires automatically on arrival / leaving) is roadmapped for v2.
+          const METERS_PER_FOOT  = 0.3048;
+          const THRESHOLD_FEET   = 100;
+          const THRESHOLD_METERS = THRESHOLD_FEET * METERS_PER_FOOT; // ~30.5m
           if (distance > THRESHOLD_METERS) {
-            setErrorMessage(`You must be within 1 mile of the site. You are currently ${Math.round(distance / METERS_PER_MILE * 10) / 10} miles away.`);
+            const feetAway = Math.round(distance / METERS_PER_FOOT);
+            setErrorMessage(
+              `You must be within ${THRESHOLD_FEET} feet of the site. You are currently ${feetAway} feet away.`
+            );
             setVerificationStep('error');
             return;
           }


### PR DESCRIPTION
## Summary

Closes Cory's stakeholder ask from 3/24: "within 100 ft he wants bio authentication when arriving and leaving."

## What lands

In `TicketDetailScreen` start-task verification:
- `THRESHOLD_METERS` switched from 1 mile (1609m) to 100ft (~30.5m).
- Error message now reports distance in feet ("You are currently 247 feet away") instead of fractional miles, since the threshold is small enough that feet is the readable unit.

## Out of scope

The full geofence-triggered biometric (auto-prompt biometric the moment the contractor crosses the 100ft boundary, with no manual Start tap) is the larger spec Cory described. That requires location watching, transition detection, and biometric integration in the background. Roadmapped for v2.

This commit aligns the existing manual proximity check with the same distance value, so when v2 lands the threshold doesn't change again.

## Test plan

- [ ] Login as `demo` / `demo123`, open an assigned ticket
- [ ] Tap Start Task while >100ft from the site → error reads "You must be within 100 feet of the site. You are currently N feet away."
- [ ] Within 100ft → start verification proceeds as before