### PR TITLE
feat(map): tickets-on-map screen with status pins and Navigate deeplink

### DIFF
--- a/backend/app/blueprints/tickets/schemas.py
+++ b/backend/app/blueprints/tickets/schemas.py
@@ -1,14 +1,23 @@
 from marshmallow_sqlalchemy import auto_field
 
 from app.extensions import ma
-from app.models import Ticket
+from app.models import Ticket, Work_order
 from marshmallow import fields, Schema, validate
+
+
+class WorkOrderLiteSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Work_order
+        fields = ("id", "latitude", "longitude", "location", "location_type")
+
 
 class TicketSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Ticket
         include_fk = True
     id = auto_field(dump_only=True)
+    work_order = fields.Nested(WorkOrderLiteSchema, dump_only=True)
+
 
 class TicketUpdateSchema(Schema):
     notes = fields.Str(required=False)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -656,6 +656,8 @@ class Ticket(Base):
     created_by: Mapped[str] = mapped_column(ForeignKey('auth_user.id'), nullable=False)
     updated_by: Mapped[str] = mapped_column(ForeignKey('auth_user.id'), nullable=False)
 
+    work_order = relationship("Work_order", foreign_keys=[work_order_id])
+
 
 class TicketPhoto(Base):
     """Photos uploaded by a contractor against a ticket they're assigned to.

--- a/backend/scripts/supabase_demo_map_coords.sql
+++ b/backend/scripts/supabase_demo_map_coords.sql
@@ -1,0 +1,65 @@
+-- supabase_demo_map_coords.sql
+--
+-- One-shot SQL helper to give the Tickets-on-Map showcase visible pins on a
+-- populated Supabase. Updates existing `work_order` rows that are linked to
+-- assigned tickets but have no coordinates yet, stamping them with realistic
+-- Austin-metro lat/lng + a "Site …" label.
+--
+-- Why this exists
+--   The repo's seed_dev.py is guarded against running on the shared Supabase
+--   after the May-2026 incident. That guard is correct but means new schema
+--   columns (work_order.latitude, work_order.longitude, work_order.location)
+--   stay NULL on Supabase even after seed_dev.py is updated.
+--
+--   The MapScreen only renders pins for tickets whose work_order has lat/lng.
+--   Without this update the showcase map would be empty even though the
+--   Tickets list shows real data.
+--
+-- How to run
+--   1. Open Supabase project -> SQL Editor.
+--   2. Paste this file, hit Run. Idempotent: only updates rows where
+--      latitude IS NULL, so re-running is a no-op.
+--   3. Confirm in MapScreen on the deployed app — pins should appear.
+--
+-- Coordinates clustered around Austin, TX so the demo sits on a coherent
+-- region instead of dots scattered across the country.
+
+WITH demo_sites(rn, lat, lng, label) AS (
+    VALUES
+        (1, 30.2672, -97.7431, 'Site A — Downtown'),
+        (2, 30.3105, -97.7220, 'Site B — North Loop'),
+        (3, 30.2402, -97.7140, 'Site C — East Riverside'),
+        (4, 30.2419, -97.7813, 'Site D — South Lamar'),
+        (5, 30.4083, -97.6680, 'Site E — Round Rock'),
+        (6, 30.2960, -97.8120, 'Site F — West Lake Hills')
+),
+candidate_work_orders AS (
+    -- Take the 6 most recently assigned tickets that don't yet have map
+    -- coords on their underlying work_order. Limits blast radius: even if
+    -- there are hundreds of tickets we only stamp a handful.
+    SELECT
+        wo.id AS work_order_id,
+        ROW_NUMBER() OVER (ORDER BY t.assigned_at DESC NULLS LAST, t.created_at DESC) AS rn
+    FROM ticket t
+    JOIN work_order wo ON wo.id = t.work_order_id
+    WHERE wo.latitude IS NULL
+      AND t.status IN ('ASSIGNED', 'IN_PROGRESS', 'PENDING_APPROVAL', 'COMPLETED')
+    LIMIT 6
+)
+UPDATE work_order wo
+SET
+    latitude      = ds.lat,
+    longitude     = ds.lng,
+    location      = COALESCE(NULLIF(wo.location, ''), ds.label),
+    location_type = COALESCE(wo.location_type, 'well_site'),
+    updated_at    = NOW()
+FROM candidate_work_orders cwo
+JOIN demo_sites ds ON ds.rn = cwo.rn
+WHERE wo.id = cwo.work_order_id;
+
+-- Quick sanity check after the update.
+SELECT id, latitude, longitude, location
+FROM work_order
+WHERE latitude IS NOT NULL
+ORDER BY updated_at DESC
+LIMIT 10;

--- a/backend/seed_dev.py
+++ b/backend/seed_dev.py
@@ -39,6 +39,7 @@ from app.models import (
     AuthUser, Contractor, Vendor,
     InspectionTemplate, InspectionSection, InspectionItem,
     DutySessions, DutyLogs,
+    Client, Service, Work_order, Ticket,
 )
 
 import os
@@ -275,7 +276,133 @@ def seed_drive_time(session, contractor_id):
     return session_obj
 
 
+# ── Tickets / work orders ─────────────────────────────────────────────────────
+
+# Demo job sites clustered around Austin, TX so the map view shows pins on a
+# coherent region instead of dots scattered across the country.
+DEMO_SITES = [
+    # (label, lat, lng, status, service_name, description, hours_offset)
+    ('Site A — Downtown', 30.2672, -97.7431, 'ASSIGNED', 'Chemical Delivery',
+     'Deliver 200 gal sodium hydroxide, north loading dock', 4),
+    ('Site B — North Loop', 30.3105, -97.7220, 'ASSIGNED', 'Inspection',
+     'Routine pre-trip equipment inspection', 26),
+    ('Site C — East Riverside', 30.2402, -97.7140, 'IN_PROGRESS', 'Hauling',
+     'Haul drilling waste to disposal facility', 0),
+    ('Site D — South Lamar', 30.2419, -97.7813, 'COMPLETED', 'Chemical Delivery',
+     'Delivered hydrochloric acid, signed BOL on file', -8),
+    ('Site E — Round Rock', 30.4083, -97.6680, 'COMPLETED', 'Inspection',
+     'Quarterly safety walk, all items pass', -32),
+    ('Site F — West Lake Hills', 30.2960, -97.8120, 'PENDING_APPROVAL',
+     'Hauling', 'Sand transport, awaiting client sign-off', 2),
+]
+
+
+def seed_tickets(session, vendor, contractor, vendor_auth):
+    """Create demo work_orders + tickets so the contractor app has visible
+    pins on the map screen and realistic items in the Tickets list."""
+    print('Seeding work orders + tickets...')
+
+    # Demo client (work_order requires client_id NOT NULL).
+    client = Client(
+        client_name='Permian Basin Oilfield Services',
+        client_code='PBOS-001',
+        primary_contact_name='Jane Operations',
+        company_email='ops@pbos-demo.test',
+        company_phone='555-200-3000',
+        created_by=vendor_auth.id,
+        updated_by=vendor_auth.id,
+    )
+    session.add(client)
+    session.flush()
+
+    # Service catalog used by both work_orders and tickets (service_type FK).
+    service_names = sorted({site[4] for site in DEMO_SITES})
+    services = {}
+    for name in service_names:
+        svc = Service(
+            service=name,
+            created_by=vendor_auth.id,
+            updated_by=vendor_auth.id,
+        )
+        session.add(svc)
+        session.flush()
+        services[name] = svc
+
+    for label, lat, lng, status, service_name, description, hours_offset in DEMO_SITES:
+        due = now_utc() + timedelta(hours=hours_offset)
+        wo = Work_order(
+            assigned_vendor=vendor.id,
+            client_id=client.id,
+            description=description,
+            current_status=status,
+            location=label,
+            location_type='well_site',
+            latitude=lat,
+            longitude=lng,
+            priority='HIGH' if status in ('IN_PROGRESS', 'PENDING_APPROVAL') else 'MEDIUM',
+            service_type=services[service_name].id,
+            estimated_start_date=due - timedelta(hours=1),
+            estimated_end_date=due + timedelta(hours=2),
+            created_by=vendor_auth.id,
+            updated_by=vendor_auth.id,
+        )
+        session.add(wo)
+        session.flush()
+
+        ticket = Ticket(
+            work_order_id=wo.id,
+            description=description,
+            assigned_contractor=contractor.id,
+            priority=wo.priority,
+            status=status,
+            vendor_id=vendor.id,
+            due_date=due,
+            assigned_at=now_utc() - timedelta(hours=1),
+            service_type=services[service_name].id,
+            notes=None,
+            created_by=vendor_auth.id,
+            updated_by=vendor_auth.id,
+        )
+        # For COMPLETED / IN_PROGRESS, fill in the contractor start coords so
+        # the demo shows a realistic "task captured location" trail.
+        if status in ('IN_PROGRESS', 'COMPLETED', 'PENDING_APPROVAL'):
+            ticket.start_time = now_utc() - timedelta(hours=2)
+            ticket.contractor_start_latitude = lat
+            ticket.contractor_start_longitude = lng
+        if status in ('COMPLETED', 'PENDING_APPROVAL'):
+            ticket.end_time = now_utc() - timedelta(hours=1)
+            ticket.contractor_end_latitude = lat
+            ticket.contractor_end_longitude = lng
+        session.add(ticket)
+
+    session.commit()
+    print(f'  [OK] {len(DEMO_SITES)} tickets across {len(services)} services, anchored on Austin metro')
+
+
 # ── Main ──────────────────────────────────────────────────────────────────────
+
+def seed_tickets_only():
+    """Run only seed_tickets, looking up existing demo vendor/contractor by
+    username. Used to add map-ready demo tickets to a populated database
+    (e.g. Supabase) without re-seeding users or inspection templates."""
+    with app.app_context():
+        vendor_auth = db.session.query(AuthUser).filter_by(username='vendor').first()
+        contractor_auth = db.session.query(AuthUser).filter_by(username='aldo').first()
+        if not vendor_auth or not contractor_auth:
+            print('REFUSING: --tickets-only requires existing "vendor" and "aldo" users.')
+            print('  Run the full seed first, or insert those users manually.')
+            raise SystemExit(2)
+        vendor = db.session.query(Vendor).filter_by(created_by=vendor_auth.id).first()
+        contractor = db.session.query(Contractor).filter_by(user_id=contractor_auth.id).first()
+        if not vendor or not contractor:
+            print('REFUSING: existing users found but vendor/contractor profiles missing.')
+            raise SystemExit(2)
+        seed_tickets(db.session, vendor, contractor, vendor_auth)
+        print()
+        print('=' * 50)
+        print('Tickets-only seed complete!')
+        print('=' * 50)
+
 
 def seed():
     with app.app_context():
@@ -285,8 +412,7 @@ def seed():
         vendor_auth, vendor, contractor_auth, contractor = seed_users(db.session)
         seed_inspection_template(db.session, created_by=vendor_auth.id)
         seed_drive_time(db.session, contractor.id)
-        # seed_tickets is intentionally absent. Tickets/Work_orders schema is
-        # still in flux on team Supabase — add back once the columns are stable.
+        seed_tickets(db.session, vendor, contractor, vendor_auth)
 
         print()
         print('=' * 50)
@@ -296,12 +422,20 @@ def seed():
 
 
 if __name__ == '__main__':
+    import sys
+    tickets_only = '--tickets-only' in sys.argv
+
     # ── Safety guard ────────────────────────────────────────────────────────
     # The May-2026 incident happened when seed scripts ran against the shared
     # Render/Supabase DB. wipe() has been removed, but seeding can still
     # create duplicate / conflicting rows on a populated shared DB and may
     # leak demo passwords into prod. Block any non-SQLite target unless
     # explicitly opted in.
+    #
+    # --tickets-only is the safer subset for remote runs (no auth users, no
+    # password hashes, just demo work_orders + tickets). It still requires
+    # ALLOW_DESTRUCTIVE_SEED=1 against a remote DB so a tired engineer can't
+    # `python seed_dev.py --tickets-only` straight into production by accident.
     db_url = os.environ.get('DATABASE_URL', '')
     if db_url and not db_url.startswith('sqlite'):
         if os.environ.get('ALLOW_DESTRUCTIVE_SEED') != '1':
@@ -311,8 +445,13 @@ if __name__ == '__main__':
             print('  DATABASE_URL =', db_url.split('@')[-1])  # show host only
             print()
             print('To run anyway, set ALLOW_DESTRUCTIVE_SEED=1 in your env.')
+            if not tickets_only:
+                print('Consider --tickets-only if you only need demo tickets.')
             print('Coordinate with the team lead first — see DATABASE_SAFETY.md.')
             print('=' * 60)
             raise SystemExit(1)
 
-    seed()
+    if tickets_only:
+        seed_tickets_only()
+    else:
+        seed()

--- a/frontend/field-force-contractor/App.tsx
+++ b/frontend/field-force-contractor/App.tsx
@@ -29,6 +29,7 @@ import { SavedReportsScreen } from "./screens/SavedReportsScreen";
 import { SplashScreen } from "./screens/SplashScreen";
 import TicketDetailScreen from "./screens/TicketDetailScreen";
 import TicketsScreen from "./screens/TicketsScreen";
+import MapScreen from "./screens/MapScreen";
 
 // ── TROY — Auth screens ──────────────────────────────────────
 import BiometricScreen from "./screens/BiometricScreen";
@@ -59,6 +60,7 @@ export type RootStackParamList = {
   Chat: { name: string; contactId?: string };
   Tickets: undefined;
   TicketDetail: { taskId: number; inspectionDone?: boolean };
+  TicketsMap: undefined;
 
   // ── Jonathan — Work Orders (placeholder until real screen built) ──
   JobDetail: { jobId: string; workOrderId: string };
@@ -142,6 +144,7 @@ function RootNavigator() {
           <StackNavigator.Screen name="Chat"             component={Chat}                    />
           <StackNavigator.Screen name="Tickets"          component={TicketsScreen}           />
           <StackNavigator.Screen name="TicketDetail"     component={TicketDetailScreen}      />
+          <StackNavigator.Screen name="TicketsMap"       component={MapScreen}               />
           <StackNavigator.Screen name="Profile"          component={ProfileScreen}           />
           <StackNavigator.Screen name="LicenseDetails"   component={LicenseScreen}           />
           <StackNavigator.Screen name="TaskHistory"      component={TaskHistoryScreen}       />

--- a/frontend/field-force-contractor/package-lock.json
+++ b/frontend/field-force-contractor/package-lock.json
@@ -15,29 +15,34 @@
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.2.2",
         "@react-navigation/native-stack": "^7.14.10",
-        "expo": "~54.0.33",
+        "expo": "~54.0.34",
+        "expo-asset": "~12.0.10",
         "expo-constants": "~18.0.13",
         "expo-file-system": "~19.0.22",
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
         "expo-image-picker": "~17.0.11",
-        "expo-linking": "~8.0.11",
+        "expo-linking": "~8.0.12",
         "expo-local-authentication": "~17.0.8",
         "expo-location": "~19.0.8",
+        "expo-print": "~15.0.7",
         "expo-secure-store": "~15.0.8",
+        "expo-sharing": "~14.0.7",
         "expo-speech-recognition": "^3.1.3",
         "expo-splash-screen": "~31.0.13",
         "expo-sqlite": "~16.0.9",
         "expo-status-bar": "~3.0.9",
         "expo-symbols": "~1.0.8",
         "expo-system-ui": "~6.0.9",
-        "expo-web-browser": "~15.0.10",
+        "expo-web-browser": "~15.0.11",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-get-random-values": "~1.11.0",
+        "react-native-maps": "1.20.1",
+        "react-native-markdown-display": "^7.0.2",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
@@ -1899,9 +1904,9 @@
       }
     },
     "node_modules/@expo/fingerprint": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.15.4.tgz",
-      "integrity": "sha512-eYlxcrGdR2/j2M6pEDXo9zU9KXXF1vhP+V+Tl+lyY+bU8lnzrN6c637mz6Ye3em2ANy8hhUR03Raf8VsT9Ogng==",
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.15.5.tgz",
+      "integrity": "sha512-mdVoAMcux1WlM6kd1RoWiHRNqKqS+J6mKmWQ/BKgeh937S/fcW58EE68O6nc4KDXtWi3PBeNHskOFcgyIuD4hw==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -1911,7 +1916,7 @@
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
         "ignore": "^5.3.1",
-        "minimatch": "^9.0.0",
+        "minimatch": "^10.2.2",
         "p-limit": "^3.1.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.6.0"
@@ -1920,25 +1925,37 @@
         "fingerprint": "bin/cli.js"
       }
     },
+    "node_modules/@expo/fingerprint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/@expo/fingerprint/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@expo/fingerprint/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1984,9 +2001,9 @@
       }
     },
     "node_modules/@expo/json-file": {
-      "version": "10.0.12",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.12.tgz",
-      "integrity": "sha512-inbDycp1rMAelAofg7h/mMzIe+Owx6F7pur3XdQ3EPTy00tme+4P6FWgHKUcjN8dBSrnbRNpSyh5/shzHyVCyQ==",
+      "version": "10.0.14",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.14.tgz",
+      "integrity": "sha512-yWwBFywFv+SxkJp/pIzzA416JVYflNUh7pqQzgaA6nXDqRyK7KfrqVzk8PdUfDnqbBcaZZxpzNssfQZzp5KHrA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -2016,9 +2033,9 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "54.0.14",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.14.tgz",
-      "integrity": "sha512-hxpLyDfOR4L23tJ9W1IbJJsG7k4lv2sotohBm/kTYyiG+pe1SYCAWsRmgk+H42o/wWf/HQjE5k45S5TomGLxNA==",
+      "version": "54.0.15",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.15.tgz",
+      "integrity": "sha512-SqIya4VZ9KHM1S9g+xR0A+QKw1Tfs7Gacx6bQNJ98vs4+O7I5+QP5mHZIB0QSZLUV8opiXebHYTiTu+0OAsIUw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -2039,7 +2056,7 @@
         "hermes-parser": "^0.29.1",
         "jsc-safe-url": "^0.2.4",
         "lightningcss": "^1.30.1",
-        "minimatch": "^9.0.0",
+        "picomatch": "^4.0.3",
         "postcss": "~8.4.32",
         "resolve-from": "^5.0.0"
       },
@@ -2052,28 +2069,16 @@
         }
       }
     },
-    "node_modules/@expo/metro-config/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+    "node_modules/@expo/metro-config/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@expo/ngrok": {
@@ -2279,9 +2284,9 @@
       }
     },
     "node_modules/@expo/osascript": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.4.2.tgz",
-      "integrity": "sha512-/XP7PSYF2hzOZzqfjgkoWtllyeTN8dW3aM4P6YgKcmmPikKL5FdoyQhti4eh6RK5a5VrUXJTOlTNIpIHsfB5Iw==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.4.3.tgz",
+      "integrity": "sha512-wbuj3EebM7W9hN/Wp4xTzKd6rQ2zKJzAxkFxkOOwyysLp0HOAgQ4/5RINyoS241pZUX2rUHq7mAJ7pcCQ8U0Ow==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2"
@@ -2291,12 +2296,12 @@
       }
     },
     "node_modules/@expo/package-manager": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.10.3.tgz",
-      "integrity": "sha512-ZuXiK/9fCrIuLjPSe1VYmfp0Sa85kCMwd8QQpgyi5ufppYKRtLBg14QOgUqj8ZMbJTxE0xqzd0XR7kOs3vAK9A==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.10.5.tgz",
+      "integrity": "sha512-nCP9Mebfl3jvOr0/P6VAuyah6PAtun+aihIL2zAtuE8uSe94JWkVZ7051i0MUVO+y3gFpBqnr8IIH5ch+VJjHA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/json-file": "^10.0.12",
+        "@expo/json-file": "^10.0.14",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
         "npm-package-arg": "^11.0.0",
@@ -2396,9 +2401,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/xcpretty": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.1.tgz",
-      "integrity": "sha512-KZNxZvnGCtiM2aYYZ6Wz0Ix5r47dAvpNLApFtZWnSoERzAdOMzVBOPysBoM0JlF6FKWZ8GPqgn6qt3dV/8Zlpg==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.4.tgz",
+      "integrity": "sha512-4aQzz9vgxcNXFfo/iyNgDDYfsU5XGKKxWxZopw0cVotHiW+U8IJbIxMaxsINs6bHhtkG3StKNPcOrn3eBuxKPw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -3249,6 +3254,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
@@ -4848,6 +4859,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001784",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
@@ -5173,6 +5193,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-in-js-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
@@ -5180,6 +5209,17 @@
       "license": "MIT",
       "dependencies": {
         "hyphenate-style-name": "^1.0.3"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/csstype": {
@@ -5510,6 +5550,12 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/env-editor": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/env-editor/-/env-editor-0.4.2.tgz",
@@ -5611,7 +5657,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6145,29 +6190,29 @@
       }
     },
     "node_modules/expo": {
-      "version": "54.0.33",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
-      "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
+      "version": "54.0.34",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.34.tgz",
+      "integrity": "sha512-XkVHguZZDC8BcTQxHAd14/TQFbDp1Wt0Z/KApO9t68Ll5A127hLCPzU+a9gytfCIiyL/V1IpF1vIcOLKEVAoNQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "54.0.23",
+        "@expo/cli": "54.0.24",
         "@expo/config": "~12.0.13",
         "@expo/config-plugins": "~54.0.4",
         "@expo/devtools": "0.1.8",
-        "@expo/fingerprint": "0.15.4",
+        "@expo/fingerprint": "0.15.5",
         "@expo/metro": "~54.2.0",
-        "@expo/metro-config": "54.0.14",
+        "@expo/metro-config": "54.0.15",
         "@expo/vector-icons": "^15.0.3",
         "@ungap/structured-clone": "^1.3.0",
         "babel-preset-expo": "~54.0.10",
-        "expo-asset": "~12.0.12",
+        "expo-asset": "~12.0.13",
         "expo-constants": "~18.0.13",
-        "expo-file-system": "~19.0.21",
+        "expo-file-system": "~19.0.22",
         "expo-font": "~14.0.11",
         "expo-keep-awake": "~15.0.8",
-        "expo-modules-autolinking": "3.0.24",
-        "expo-modules-core": "3.0.29",
+        "expo-modules-autolinking": "3.0.25",
+        "expo-modules-core": "3.0.30",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
         "whatwg-url-without-unicode": "8.0.0-3"
@@ -6197,13 +6242,13 @@
       }
     },
     "node_modules/expo-asset": {
-      "version": "12.0.12",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.12.tgz",
-      "integrity": "sha512-CsXFCQbx2fElSMn0lyTdRIyKlSXOal6ilLJd+yeZ6xaC7I9AICQgscY5nj0QcwgA+KYYCCEQEBndMsmj7drOWQ==",
+      "version": "12.0.13",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.13.tgz",
+      "integrity": "sha512-x/p7WvQUnkn6K43b9eL6SPeq5Vnf1E8BDe9bDrWrvMqzyUvJnUFvl+ctg3034s/+UHe7Ne2pAmc0+yzbl8CrDQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/image-utils": "^0.8.8",
-        "expo-constants": "~18.0.12"
+        "expo-constants": "~18.0.13"
       },
       "peerDependencies": {
         "expo": "*",
@@ -6307,12 +6352,12 @@
       }
     },
     "node_modules/expo-linking": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.11.tgz",
-      "integrity": "sha512-+VSaNL5om3kOp/SSKO5qe6cFgfSIWnnQDSbA7XLs3ECkYzXRquk5unxNS3pg7eK5kNUmQ4kgLI7MhTggAEUBLA==",
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.12.tgz",
+      "integrity": "sha512-FpXeIpFgZuxihwT9lBo86YD3y6LphBuAhN680MMxm/Y7fmsc57vimn2d3vFu68VI0+Z9w457t494mu2wvlgWTQ==",
       "license": "MIT",
       "dependencies": {
-        "expo-constants": "~18.0.12",
+        "expo-constants": "~18.0.13",
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
@@ -6342,9 +6387,9 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "3.0.24",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.24.tgz",
-      "integrity": "sha512-TP+6HTwhL7orDvsz2VzauyQlXJcAWyU3ANsZ7JGL4DQu8XaZv/A41ZchbtAYLfozNA2Ya1Hzmhx65hXryBMjaQ==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.25.tgz",
+      "integrity": "sha512-YmHWctJlwvOuLZccg3cOXvSiXVJrPMKl7g2YR0YHWoGL9v2RvcmgaPJWPSLVW+voNEgEPsbo5UmUrAqbnYcBeg==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -6358,15 +6403,25 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "3.0.29",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.29.tgz",
-      "integrity": "sha512-LzipcjGqk8gvkrOUf7O2mejNWugPkf3lmd9GkqL9WuNyeN2fRwU0Dn77e3ZUKI3k6sI+DNwjkq4Nu9fNN9WS7Q==",
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.30.tgz",
+      "integrity": "sha512-a6IrpAn/Jbmwxi9L+hMmXKpNqnkUpoF7WHOpn02rVLyax2J0gB1vvCVE5rNydplEnt41Q6WxQwvcOjZaIkcSUg==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
         "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-print": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-print/-/expo-print-15.0.8.tgz",
+      "integrity": "sha512-4O0Qzm0On5AmJIl9d+BT+ieTipFp658nHI4aX7vKEFPfj3dfQxG6rDJJpca+rrc9c4Ha8ZFYGvxJG5+4lFq2Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
         "react-native": "*"
       }
     },
@@ -6380,12 +6435,21 @@
       }
     },
     "node_modules/expo-server": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.5.tgz",
-      "integrity": "sha512-IGR++flYH70rhLyeXF0Phle56/k4cee87WeQ4mamS+MkVAVP+dDlOHf2nN06Z9Y2KhU0Gp1k+y61KkghF7HdhA==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.6.tgz",
+      "integrity": "sha512-vb5TBtskvEdzYuW79lATXutOEBfW5m6U4EFpNjCVZTnI7S//SAsLQkYEpn+EDfn84m6VQfzSGkIVR6YPaScKFA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/expo-sharing": {
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-14.0.8.tgz",
+      "integrity": "sha512-A1pPr2iBrxypFDCWVAESk532HK+db7MFXbvO2sCV9ienaFXAk7lIBm6bkqgE6vzRd9O3RGdEGzYx80cYlc089Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-speech-recognition": {
@@ -6472,9 +6536,9 @@
       }
     },
     "node_modules/expo-web-browser": {
-      "version": "15.0.10",
-      "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-15.0.10.tgz",
-      "integrity": "sha512-fvDhW4bhmXAeWFNFiInmsGCK83PAqAcQaFyp/3pE/jbdKmFKoRCWr46uZGIfN4msLK/OODhaQ/+US7GSJNDHJg==",
+      "version": "15.0.11",
+      "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-15.0.11.tgz",
+      "integrity": "sha512-r2LS4Ro6DgUPZkcaEfgt8mp9eJuoA93x11Jh7S6utFe0FEzvUNn2yFhxg8XVwESaaHGt2k5V8LuK36rsp0BeIw==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -6482,9 +6546,9 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {
-      "version": "54.0.23",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.23.tgz",
-      "integrity": "sha512-km0h72SFfQCmVycH/JtPFTVy69w6Lx1cHNDmfLfQqgKFYeeHTjx7LVDP4POHCtNxFP2UeRazrygJhlh4zz498g==",
+      "version": "54.0.24",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.24.tgz",
+      "integrity": "sha512-5xse1bEgnVUBhOrtttc6xTNJVvjyTRavpzuF0/0nuj+312vfSbk7EiRbG+xJ2pW/iZxnhLPJkFCrPYG0nmheAQ==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.8",
@@ -6496,7 +6560,7 @@
         "@expo/image-utils": "^0.8.8",
         "@expo/json-file": "^10.0.8",
         "@expo/metro": "~54.2.0",
-        "@expo/metro-config": "~54.0.14",
+        "@expo/metro-config": "~54.0.15",
         "@expo/osascript": "^2.3.8",
         "@expo/package-manager": "^1.9.10",
         "@expo/plist": "^0.4.8",
@@ -6519,16 +6583,16 @@
         "connect": "^3.7.0",
         "debug": "^4.3.4",
         "env-editor": "^0.4.1",
-        "expo-server": "^1.0.5",
+        "expo-server": "^1.0.6",
         "freeport-async": "^2.0.0",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
-        "lan-network": "^0.1.6",
+        "lan-network": "^0.2.1",
         "minimatch": "^9.0.0",
         "node-forge": "^1.3.3",
         "npm-package-arg": "^11.0.0",
         "ora": "^3.4.0",
-        "picomatch": "^3.0.1",
+        "picomatch": "^4.0.3",
         "pretty-bytes": "^5.6.0",
         "pretty-format": "^29.7.0",
         "progress": "^2.0.3",
@@ -6569,9 +6633,9 @@
       }
     },
     "node_modules/expo/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6608,23 +6672,24 @@
       }
     },
     "node_modules/expo/node_modules/picomatch": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.2.tgz",
-      "integrity": "sha512-cfDHL6LStTEKlNilboNtobT/kEa30PtAf2Q1OgszfrG/rpVl1xaFWT9ktfkS306GmHgmnad1Sw4wabhlvFtsTw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/expo/node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -8375,9 +8440,9 @@
       }
     },
     "node_modules/lan-network": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/lan-network/-/lan-network-0.1.7.tgz",
-      "integrity": "sha512-mnIlAEMu4OyEvUNdzco9xpuB9YVcPkQec+QsgycBCtPZvEqWPCDPfbAE4OJMdBBWpZWtpCn1xw9jJYlwjWI5zQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/lan-network/-/lan-network-0.2.1.tgz",
+      "integrity": "sha512-ONPnazC96VKDntab9j9JKwIWhZ4ZUceB4A9Epu4Ssg0hYFmtHZSeQ+n15nIwTFmcBUKtExOer8WTJ4GF9MO64A==",
       "license": "MIT",
       "bin": {
         "lan-network": "dist/lan-network-cli.js"
@@ -8567,6 +8632,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8586,6 +8654,9 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -8607,6 +8678,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8626,6 +8700,9 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -8685,6 +8762,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
+    },
+    "node_modules/linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -8844,6 +8930,31 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "entities": "~2.0.0",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/marky": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
@@ -8859,6 +8970,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "license": "MIT"
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -10161,7 +10278,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -10173,7 +10289,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pump": {
@@ -10383,6 +10498,15 @@
         }
       }
     },
+    "node_modules/react-native-fit-image": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/react-native-fit-image/-/react-native-fit-image-1.5.5.tgz",
+      "integrity": "sha512-Wl3Vq2DQzxgsWKuW4USfck9zS7YzhvLNPpkwUUCF90bL32e1a0zOVQ3WsJILJOwzmPdHfzZmWasiiAUNBkhNkg==",
+      "license": "Beerware",
+      "dependencies": {
+        "prop-types": "^15.5.10"
+      }
+    },
     "node_modules/react-native-gesture-handler": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
@@ -10418,6 +10542,44 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-maps": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.20.1.tgz",
+      "integrity": "sha512-NZI3B5Z6kxAb8gzb2Wxzu/+P2SlFIg1waHGIpQmazDSCRkNoHNY4g96g+xS0QPSaG/9xRBbDNnd2f2/OW6t6LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.13"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": ">= 17.0.1",
+        "react-native": ">= 0.64.3",
+        "react-native-web": ">= 0.11"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native-markdown-display": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-markdown-display/-/react-native-markdown-display-7.0.2.tgz",
+      "integrity": "sha512-Mn4wotMvMfLAwbX/huMLt202W5DsdpMO/kblk+6eUs55S57VVNni1gzZCh5qpznYLjIQELNh50VIozEfY6fvaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-to-react-native": "^3.0.0",
+        "markdown-it": "^10.0.0",
+        "prop-types": "^15.7.2",
+        "react-native-fit-image": "^1.5.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.2.0",
+        "react-native": ">=0.50.4"
       }
     },
     "node_modules/react-native-reanimated": {
@@ -11691,9 +11853,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -12097,6 +12259,12 @@
         "node": "*"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "license": "MIT"
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -12117,9 +12285,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/frontend/field-force-contractor/package.json
+++ b/frontend/field-force-contractor/package.json
@@ -44,6 +44,7 @@
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-get-random-values": "~1.11.0",
+    "react-native-maps": "1.20.1",
     "react-native-markdown-display": "^7.0.2",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/frontend/field-force-contractor/screens/MapScreen.tsx
+++ b/frontend/field-force-contractor/screens/MapScreen.tsx
@@ -1,0 +1,305 @@
+// MapScreen — assigned-tickets plotted on a map.
+//
+// Pulls /contractors/assigned-tickets and drops a status-coloured pin per
+// ticket whose `work_order` carries lat/lng. Tap a pin -> callout with
+// service title, location label, and a Navigate button that hands off to
+// Apple/Google Maps via the same Linking pattern used in TicketDetailScreen.
+//
+// Tickets without work_order coordinates are silently filtered out of the
+// pins list and surfaced in a footer pill ("3 tickets without location") so
+// the contractor knows the map is incomplete instead of wondering where a
+// ticket went.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Linking,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import MapView, { Callout, Marker, PROVIDER_DEFAULT } from 'react-native-maps';
+
+import { SubHeader } from '../components/MainFrame';
+import { api } from '../utils/api';
+import { ticketDisplayTitle } from '../utils/ticketLabels';
+
+interface WorkOrderLite {
+  id: string;
+  latitude: string | number | null;
+  longitude: string | number | null;
+  location: string | null;
+  location_type: string | null;
+}
+
+interface BackendTicket {
+  id: string;
+  description: string | null;
+  status: string;
+  service_type: string | null;
+  due_date: string | null;
+  work_order: WorkOrderLite | null;
+}
+
+interface PinTicket extends BackendTicket {
+  lat: number;
+  lng: number;
+  locationLabel: string;
+}
+
+const STATUS_PIN: Record<string, string> = {
+  ASSIGNED: '#f59e0b',         // amber
+  IN_PROGRESS: '#3b82f6',      // blue
+  PENDING_APPROVAL: '#a78bfa', // violet
+  COMPLETED: '#22c55e',        // green
+  APPROVED: '#22c55e',
+};
+
+// Fallback region (Austin, TX) for when there are zero pins to fit.
+const FALLBACK_REGION = {
+  latitude: 30.2672,
+  longitude: -97.7431,
+  latitudeDelta: 0.4,
+  longitudeDelta: 0.4,
+};
+
+function toPin(t: BackendTicket): PinTicket | null {
+  const wo = t.work_order;
+  if (!wo) return null;
+  const lat = wo.latitude == null ? NaN : Number(wo.latitude);
+  const lng = wo.longitude == null ? NaN : Number(wo.longitude);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  return {
+    ...t,
+    lat,
+    lng,
+    locationLabel: wo.location?.trim() || 'Job site',
+  };
+}
+
+function pinColor(status: string): string {
+  return STATUS_PIN[(status || '').toUpperCase()] ?? '#9ca3af';
+}
+
+export default function MapScreen() {
+  const navigation = useNavigation<any>();
+  const mapRef = useRef<MapView | null>(null);
+  const [tickets, setTickets] = useState<BackendTicket[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTickets = useCallback(async () => {
+    setError(null);
+    try {
+      const rows = await api.authGet<BackendTicket[]>('/contractors/assigned-tickets');
+      setTickets(rows ?? []);
+    } catch {
+      setError("Couldn't load tickets. Pull down to refresh.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useFocusEffect(useCallback(() => {
+    fetchTickets().catch(() => {});
+  }, [fetchTickets]));
+
+  const pins = tickets.map(toPin).filter((p): p is PinTicket => p !== null);
+  const missingLocationCount = tickets.length - pins.length;
+
+  // Fit-to-pins after data lands.
+  useEffect(() => {
+    if (!mapRef.current || pins.length === 0) return;
+    mapRef.current.fitToCoordinates(
+      pins.map(p => ({ latitude: p.lat, longitude: p.lng })),
+      { edgePadding: { top: 80, right: 60, bottom: 120, left: 60 }, animated: true },
+    );
+  }, [pins.length]);
+
+  const handleNavigate = (p: PinTicket) => {
+    const url = `https://maps.google.com/?q=${p.lat},${p.lng}`;
+    Linking.openURL(url);
+  };
+
+  const handleOpenTicket = (p: PinTicket) => {
+    navigation.navigate('TicketDetail' as never, { taskId: p.id, assigned: true } as never);
+  };
+
+  return (
+    <View style={styles.root}>
+      <SubHeader title="Tickets map" />
+
+      <View style={styles.mapWrap}>
+        <MapView
+          ref={mapRef}
+          provider={PROVIDER_DEFAULT}
+          style={StyleSheet.absoluteFill}
+          initialRegion={FALLBACK_REGION}
+          showsUserLocation
+          showsMyLocationButton
+        >
+          {pins.map(p => (
+            <Marker
+              key={p.id}
+              coordinate={{ latitude: p.lat, longitude: p.lng }}
+              pinColor={pinColor(p.status)}
+            >
+              <Callout tooltip={false} onPress={() => handleOpenTicket(p)}>
+                <View style={styles.callout}>
+                  <Text style={styles.calloutTitle} numberOfLines={2}>
+                    {ticketDisplayTitle(p)}
+                  </Text>
+                  <Text style={styles.calloutMeta}>
+                    {p.locationLabel} · {(p.status || '').replace('_', ' ')}
+                  </Text>
+                  <View style={styles.calloutRow}>
+                    <TouchableOpacity
+                      style={[styles.calloutBtn, styles.calloutBtnPrimary]}
+                      onPress={() => handleNavigate(p)}
+                    >
+                      <Ionicons name="navigate" size={14} color="white" />
+                      <Text style={styles.calloutBtnText}>Navigate</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={[styles.calloutBtn, styles.calloutBtnGhost]}
+                      onPress={() => handleOpenTicket(p)}
+                    >
+                      <Text style={[styles.calloutBtnText, { color: '#0f172a' }]}>
+                        Open
+                      </Text>
+                    </TouchableOpacity>
+                  </View>
+                </View>
+              </Callout>
+            </Marker>
+          ))}
+        </MapView>
+
+        {loading && (
+          <View style={styles.loadingOverlay} pointerEvents="none">
+            <ActivityIndicator size="large" color="#9ca3af" />
+          </View>
+        )}
+
+        {error && (
+          <View style={styles.errorPill}>
+            <Ionicons name="alert-circle-outline" size={14} color="#fca5a5" />
+            <Text style={styles.errorText}>{error}</Text>
+          </View>
+        )}
+
+        {!loading && pins.length === 0 && !error && (
+          <View style={styles.emptyOverlay}>
+            <Ionicons name="map-outline" size={32} color="rgba(255,255,255,0.6)" />
+            <Text style={styles.emptyText}>No tickets with location data yet.</Text>
+          </View>
+        )}
+
+        {missingLocationCount > 0 && (
+          <View style={styles.missingPill}>
+            <Ionicons name="information-circle-outline" size={14} color="#cbd5e1" />
+            <Text style={styles.missingText}>
+              {missingLocationCount} ticket{missingLocationCount === 1 ? '' : 's'} without location
+            </Text>
+          </View>
+        )}
+
+        {/* Status legend */}
+        <View style={styles.legend}>
+          <LegendDot color={STATUS_PIN.ASSIGNED} label="Assigned" />
+          <LegendDot color={STATUS_PIN.IN_PROGRESS} label="In progress" />
+          <LegendDot color={STATUS_PIN.COMPLETED} label="Done" />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <View style={styles.legendItem}>
+      <View style={[styles.legendDot, { backgroundColor: color }]} />
+      <Text style={styles.legendLabel}>{label}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: '#0a0e1a' },
+  mapWrap: { flex: 1, position: 'relative' },
+
+  loadingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emptyOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(10,14,26,0.6)',
+    gap: 8,
+  },
+  emptyText: { color: 'rgba(255,255,255,0.85)', fontSize: 14 },
+
+  errorPill: {
+    position: 'absolute',
+    top: 12,
+    alignSelf: 'center',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    backgroundColor: 'rgba(127,29,29,0.85)',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+  },
+  errorText: { color: '#fecaca', fontSize: 12 },
+
+  missingPill: {
+    position: 'absolute',
+    bottom: 14,
+    alignSelf: 'center',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    backgroundColor: 'rgba(15,23,42,0.85)',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+  },
+  missingText: { color: '#e2e8f0', fontSize: 12 },
+
+  legend: {
+    position: 'absolute',
+    top: 12,
+    right: 12,
+    backgroundColor: 'rgba(15,23,42,0.85)',
+    borderRadius: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    gap: 4,
+  },
+  legendItem: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  legendDot: { width: 10, height: 10, borderRadius: 5 },
+  legendLabel: { color: 'white', fontSize: 11 },
+
+  callout: { width: 220, gap: 6 },
+  calloutTitle: { fontSize: 13, fontWeight: '700', color: '#0f172a' },
+  calloutMeta: { fontSize: 11, color: '#475569' },
+  calloutRow: { flexDirection: 'row', gap: 6, marginTop: 4 },
+  calloutBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 8,
+  },
+  calloutBtnPrimary: { backgroundColor: '#2563eb' },
+  calloutBtnGhost: { backgroundColor: '#e2e8f0' },
+  calloutBtnText: { fontSize: 12, fontWeight: '600', color: 'white' },
+});

--- a/frontend/field-force-contractor/screens/TicketsScreen.tsx
+++ b/frontend/field-force-contractor/screens/TicketsScreen.tsx
@@ -105,12 +105,24 @@ export default function TicketsScreen() {
 
       {/* Header */}
       <View style={styles.section}>
-        <Text style={styles.title}>Tickets</Text>
-        <Text style={styles.subtitle}>
-          {loading
-            ? 'Loading...'
-            : `${action.length} action needed · ${inProgress.length} in progress · ${pending.length} pending approval`}
-        </Text>
+        <View style={styles.headerRow}>
+          <View style={{ flex: 1 }}>
+            <Text style={styles.title}>Tickets</Text>
+            <Text style={styles.subtitle}>
+              {loading
+                ? 'Loading...'
+                : `${action.length} action needed · ${inProgress.length} in progress · ${pending.length} pending approval`}
+            </Text>
+          </View>
+          <TouchableOpacity
+            style={styles.mapBtn}
+            onPress={() => navigation.navigate('TicketsMap' as never)}
+            accessibilityLabel="Open tickets map"
+          >
+            <Ionicons name="map" size={16} color="white" />
+            <Text style={styles.mapBtnText}>Map</Text>
+          </TouchableOpacity>
+        </View>
       </View>
 
       {error && (
@@ -226,8 +238,21 @@ const BORDER  = 'rgba(255,255,255,0.15)';
 
 const styles = StyleSheet.create({
     section:       { width: '90%', marginBottom: 16 },
+    headerRow:     { flexDirection: 'row', alignItems: 'flex-start', gap: 10 },
     title:         { fontSize: 22, fontFamily: 'poppins-bold', color: 'white', marginBottom: 4 },
     subtitle:      { fontSize: 13, color: '#9ca3af' },
+    mapBtn: {
+      flexDirection: 'row',
+      alignItems:    'center',
+      gap:           6,
+      paddingHorizontal: 12,
+      paddingVertical:   8,
+      borderRadius:  999,
+      backgroundColor: 'rgba(59,130,246,0.18)',
+      borderWidth:   1,
+      borderColor:   'rgba(59,130,246,0.45)',
+    },
+    mapBtnText:    { color: 'white', fontSize: 12, fontFamily: 'poppins-bold' },
     sectionHeader: { flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 8 },
     sectionTitle:  { fontSize: 13, fontFamily: 'poppins-bold', color: 'white', marginBottom: 8 },
     taskCard: {


### PR DESCRIPTION
## Summary

Adds a tickets-on-map screen to the contractor app, accessed via a new "Map" pill in the Tickets header. Pins are status-coloured (assigned/in-progress/done), each callout offers a Navigate button (deep-links to Apple/Google Maps) and an Open button (drops into existing TicketDetail). Builds on existing GPS infrastructure, no new backend models, just surfacing the already-existing `work_order.latitude/longitude/location` columns through the contractor endpoint.

Closes the visual gap where the app knew GPS for the geofence but never showed a map.

## What's in this PR

### Frontend (`field-force-contractor/`)
- **New `screens/MapScreen.tsx`** — `react-native-maps` MapView, fits to all pins on load, falls back to Austin region when there are zero pins. Status legend top-right, "X tickets without location" pill bottom-center when some tickets lack coords. Calls `/contractors/assigned-tickets` and uses the new nested `work_order` field.
- **`screens/TicketsScreen.tsx`** — adds a Map pill in the header that navigates to `TicketsMap`.
- **`App.tsx`** — registers `TicketsMap` in the stack.
- **`package.json`** — adds `react-native-maps@1.20.1` (Expo-recommended version).

### Backend (`backend/`)
- **`app/blueprints/tickets/schemas.py`** — new `WorkOrderLiteSchema` (id, latitude, longitude, location, location_type) nested on `TicketSchema` as `work_order`. Existing flat fields unchanged so the rest of the app keeps working.
- **`app/models.py`** — adds `work_order = relationship("Work_order")` on `Ticket` so the Nested field can populate.
- **`seed_dev.py`** — new `seed_tickets()` creates 6 work_orders + tickets clustered around Austin across realistic statuses (ASSIGNED, IN_PROGRESS, COMPLETED, PENDING_APPROVAL). New `--tickets-only` flag runs just the ticket seed by looking up existing demo users by username, useful for adding map data to a populated DB without re-running auth seeds. Remote-DB safety guard still applies.
- **`scripts/supabase_demo_map_coords.sql`** — no-code path: one-shot SQL that stamps lat/lng on the 6 most recent assigned-but-mapless tickets on Supabase. Idempotent (only updates `WHERE latitude IS NULL`).

## Why two paths for showcase data

The deployed Supabase has tickets but no work_order coords (those columns only got populated by the new `seed_tickets()`). Two options to light up the map on the showcase backend:

1. **SQL helper (recommended for showcase week)** — paste `backend/scripts/supabase_demo_map_coords.sql` into Supabase SQL editor. Updates existing rows, no new tickets created, lowest blast radius.
2. **`--tickets-only` seed** — `ALLOW_DESTRUCTIVE_SEED=1 python seed_dev.py --tickets-only` against Supabase. Adds 6 brand-new tickets with coords. Use if you want fresh, separate demo data instead of touching existing tickets.

## Out of scope

- Multi-stop route optimization. Navigate hands off to Maps for one ticket at a time.
- Live contractor pin on the map (showsUserLocation is enabled but no custom marker).
- Custom map tile styling.

## Test plan

**Local (this branch on Expo Go iOS, against local SQLite):**
- [ ] `cd backend && rm instance/app.db && python seed_dev.py` runs to completion with "6 tickets across 3 services"
- [ ] App login with `aldo / 123456` → Tickets screen → Map button visible top-right
- [ ] Tap Map → 6 pins render around Austin, fit-to-pins region applied
- [ ] Pin colors match status (amber = assigned, blue = in-progress, green = completed)
- [ ] Tap pin → callout shows service title + status, Navigate opens Maps app, Open routes to TicketDetail
- [ ] Header back button returns to Tickets

**Showcase backend (Render + Supabase, on the demo phone):**
- [ ] Run `backend/scripts/supabase_demo_map_coords.sql` in Supabase SQL editor
- [ ] Hard-reload the app, navigate to Tickets → Map
- [ ] At least 6 pins render (existing tickets, now with coords)
- [ ] Navigate deep-link works on iOS (opens Apple Maps with the right point)
- [ ] No regression on Tickets list, TicketDetail, or the existing geofence flow

**Edge cases:**
- [ ] Tickets without `work_order.latitude` are filtered, "N tickets without location" pill shows
- [ ] Empty state ("No tickets with location data yet") shows when zero pins
- [ ] Network error shows error pill at top, doesn't crash
