### PR TITLE
feat(signature): capture contractor signature on Complete Task

### DIFF
--- a/frontend/field-force-contractor/components/SignatureModal.tsx
+++ b/frontend/field-force-contractor/components/SignatureModal.tsx
@@ -1,0 +1,142 @@
+// SignatureModal — full-screen capture for the contractor's "proof of work"
+// signature. Built on react-native-signature-canvas (a thin WebView around
+// signature_pad). Returns a base64-encoded PNG via onConfirm, or null via
+// onCancel.
+//
+// Why a modal: the signature is only collected at Complete Task and never
+// edited from the gallery. Keeping it modal avoids cluttering the existing
+// TicketDetailScreen layout and lets the canvas use the full viewport on
+// the small phones used in the field.
+//
+// Output format:
+//   Whatever signature-canvas returns, which is the data URL form
+//   "data:image/png;base64,iVBORw0KGgo..." — the consumer strips the
+//   prefix and writes the base64 payload to a .png file.
+
+import { useRef } from 'react';
+import {
+  Modal,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import SignatureScreen, { SignatureViewRef } from 'react-native-signature-canvas';
+
+interface Props {
+  visible: boolean;
+  onConfirm: (dataUrl: string) => void;
+  onCancel: () => void;
+  signerName?: string;
+}
+
+// signature-canvas exposes its own toolbar but ours doesn't match the dark
+// theme, so suppress it with this CSS override and provide custom buttons
+// in the modal chrome.
+const WEBSTYLE = `
+  body, html { background: #ffffff; }
+  .m-signature-pad { box-shadow: none; border: none; }
+  .m-signature-pad--body { border: none; }
+  .m-signature-pad--footer { display: none; }
+`;
+
+export function SignatureModal({ visible, onConfirm, onCancel, signerName }: Props) {
+  const ref = useRef<SignatureViewRef>(null);
+
+  const handleSave = () => {
+    ref.current?.readSignature();
+  };
+
+  const handleClear = () => {
+    ref.current?.clearSignature();
+  };
+
+  // signature-canvas fires onOK with the data URL whenever readSignature()
+  // is called and the pad is non-empty. onEmpty fires if the pad has no
+  // strokes — we treat that as a no-op and prompt the user to draw first.
+  const handleOK = (dataUrl: string) => {
+    onConfirm(dataUrl);
+  };
+
+  const handleEmpty = () => {
+    // No strokes — ignore. The Save button stays available so the user can
+    // try again after drawing.
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onCancel}>
+      <View style={styles.root}>
+        <View style={styles.header}>
+          <TouchableOpacity onPress={onCancel} style={styles.headerBtn}>
+            <Ionicons name="close" size={22} color="white" />
+          </TouchableOpacity>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text style={styles.title}>Sign to complete</Text>
+            {signerName ? <Text style={styles.subtitle}>{signerName}</Text> : null}
+          </View>
+          <View style={styles.headerBtn} />
+        </View>
+
+        <View style={styles.canvasWrap}>
+          <SignatureScreen
+            ref={ref}
+            webStyle={WEBSTYLE}
+            onOK={handleOK}
+            onEmpty={handleEmpty}
+            descriptionText=""
+            penColor="#0f172a"
+            backgroundColor="#ffffff"
+            imageType="image/png"
+          />
+        </View>
+
+        <View style={styles.footer}>
+          <TouchableOpacity style={[styles.btn, styles.btnGhost]} onPress={handleClear}>
+            <Ionicons name="refresh" size={16} color="#0f172a" />
+            <Text style={[styles.btnText, { color: '#0f172a' }]}>Clear</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={[styles.btn, styles.btnPrimary]} onPress={handleSave}>
+            <Ionicons name="checkmark" size={16} color="white" />
+            <Text style={styles.btnText}>Save signature</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: '#0a0e1a' },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingTop: 56,
+    paddingBottom: 12,
+    paddingHorizontal: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: 'rgba(255,255,255,0.1)',
+  },
+  headerBtn: { width: 44, height: 44, alignItems: 'center', justifyContent: 'center' },
+  title: { color: 'white', fontSize: 16, fontFamily: 'poppins-bold' },
+  subtitle: { color: '#9ca3af', fontSize: 12, marginTop: 2 },
+  canvasWrap: { flex: 1, backgroundColor: 'white', margin: 16, borderRadius: 12, overflow: 'hidden' },
+  footer: {
+    flexDirection: 'row',
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingBottom: 32,
+  },
+  btn: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    paddingVertical: 14,
+    borderRadius: 10,
+  },
+  btnPrimary: { backgroundColor: '#2563eb' },
+  btnGhost: { backgroundColor: '#e2e8f0' },
+  btnText: { color: 'white', fontSize: 14, fontFamily: 'poppins-bold' },
+});

--- a/frontend/field-force-contractor/package-lock.json
+++ b/frontend/field-force-contractor/package-lock.json
@@ -46,7 +46,9 @@
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
+        "react-native-signature-canvas": "^5.0.2",
         "react-native-web": "~0.21.0",
+        "react-native-webview": "13.15.0",
         "react-native-worklets": "0.5.1",
         "uuid": "^13.0.0"
       },
@@ -1582,9 +1584,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1594,9 +1596,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1935,9 +1937,9 @@
       }
     },
     "node_modules/@expo/fingerprint/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3185,9 +3187,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3789,6 +3791,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3803,6 +3808,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3817,6 +3825,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3831,6 +3842,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3845,6 +3859,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3859,6 +3876,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3873,6 +3893,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3887,6 +3910,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10634,6 +10660,15 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-signature-canvas": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-signature-canvas/-/react-native-signature-canvas-5.0.2.tgz",
+      "integrity": "sha512-AYtXhuz8i5KcdOQBzbmQZGxeol9RCqYxvJGCBDTd0MJ6WiBsanjH4vH3Ft4C2MP7fYrAKyZCZPA0Ea066uEiMw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native-webview": ">=13"
+      }
+    },
     "node_modules/react-native-web": {
       "version": "0.21.2",
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
@@ -10665,6 +10700,20 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
+    },
+    "node_modules/react-native-webview": {
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.15.0.tgz",
+      "integrity": "sha512-Vzjgy8mmxa/JO6l5KZrsTC7YemSdq+qB01diA0FqjUTaWGAGwuykpJ73MDj3+mzBSlaDxAEugHzTtkUQkQEQeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/react-native-worklets": {
       "version": "0.5.1",

--- a/frontend/field-force-contractor/package.json
+++ b/frontend/field-force-contractor/package.json
@@ -49,7 +49,9 @@
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
+    "react-native-signature-canvas": "^5.0.2",
     "react-native-web": "~0.21.0",
+    "react-native-webview": "13.15.0",
     "react-native-worklets": "0.5.1",
     "uuid": "^13.0.0"
   },

--- a/frontend/field-force-contractor/screens/TicketDetailScreen.tsx
+++ b/frontend/field-force-contractor/screens/TicketDetailScreen.tsx
@@ -1,6 +1,8 @@
 import { useState, useRef, useEffect } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, TextInput, Modal, Alert, ActivityIndicator, Linking, Image } from 'react-native';
+import * as FileSystem from 'expo-file-system/legacy';
 import { uploadPhotoOrEnqueue } from '../utils/photoOutbox';
+import { SignatureModal } from '../components/SignatureModal';
 import { useNetwork } from '../contexts/NetworkContext';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, useRoute } from '@react-navigation/native';
@@ -61,6 +63,13 @@ export default function TicketDetailScreen() {
   const [analyzingUri, setAnalyzingUri]   = useState<string | null>(null);
   const [analysisOpen, setAnalysisOpen]   = useState<string | null>(null);
   const [analysisError, setAnalysisError] = useState<string | null>(null);
+
+  // Signature capture: opened by Complete Task, closed once the contractor
+  // saves a signature. signatureUri is the on-disk PNG that gets enqueued
+  // alongside the regular ticket photos.
+  const [signatureModalOpen, setSignatureModalOpen] = useState(false);
+  const [signatureUri, setSignatureUri] = useState<string | null>(null);
+
   const pinRefs = useRef<(TextInput | null)[]>([null, null, null, null, null, null]);
 
   // ── Load saved biometric preference ────────────────────────────────────────
@@ -477,11 +486,45 @@ export default function TicketDetailScreen() {
     return { sent, queued };
   };
 
-  const handleCompleteTask = async () => {
-    try {
-      const savedAccept = await AsyncStorage.getItem(`accept_location_${taskId}`);
-      const acceptLoc = savedAccept ? JSON.parse(savedAccept) : null;
+  // Signature capture flow:
+  //   1. Contractor taps "Complete Task" -> handleCompleteTask gates on
+  //      signatureUri. If absent, opens the modal and bails.
+  //   2. Modal calls handleSignatureConfirmed(dataUrl) on Save.
+  //      We strip the "data:image/png;base64," prefix, write to disk under
+  //      documentDirectory so the URI survives ImagePicker cache eviction,
+  //      then re-enter submitCompletion with the now-non-null signatureUri.
+  //   3. submitCompletion enqueues the signature alongside the regular
+  //      photos via the existing photoOutbox so durability + offline retry
+  //      are inherited for free.
 
+  const handleSignatureConfirmed = async (dataUrl: string) => {
+    setSignatureModalOpen(false);
+    try {
+      // signature-canvas yields "data:image/png;base64,...". Strip prefix
+      // before writing because writeAsStringAsync expects pure base64.
+      const base64 = dataUrl.replace(/^data:image\/[a-z]+;base64,/, '');
+      const dest = `${FileSystem.documentDirectory ?? ''}signature_${taskId}_${Date.now()}.png`;
+      await FileSystem.writeAsStringAsync(dest, base64, {
+        encoding: FileSystem.EncodingType.Base64,
+      });
+      setSignatureUri(dest);
+      // Re-enter the completion flow now that we have a signature on disk.
+      submitCompletion(dest);
+    } catch (e: any) {
+      Alert.alert('Signature error', e?.message ?? 'Could not save the signature. Please try again.');
+    }
+  };
+
+  const handleCompleteTask = async () => {
+    if (!signatureUri) {
+      setSignatureModalOpen(true);
+      return;
+    }
+    submitCompletion(signatureUri);
+  };
+
+  const submitCompletion = async (sigUri: string) => {
+    try {
       let endCoords = null;
       try {
         const endLoc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
@@ -511,8 +554,13 @@ export default function TicketDetailScreen() {
       // TODO: queue for offline retry when sync manager is built
     }
 
-    if (photoUris.length > 0) {
-      const { sent, queued } = await uploadPhotos(task.id, photoUris);
+    // Build the final photo list: real photos first, signature last so the
+    // approver sees site evidence followed by the contractor's sign-off.
+    // Both ride the same outbox; signature filename pattern keeps it
+    // distinguishable on the backend.
+    const allPhotos = [...photoUris, sigUri];
+    if (allPhotos.length > 0) {
+      const { sent, queued } = await uploadPhotos(task.id, allPhotos);
       if (queued > 0) {
         Alert.alert(
           'Photos queued',
@@ -830,9 +878,17 @@ export default function TicketDetailScreen() {
               onPress={handleCompleteTask}
               disabled={task.photosSubmitted < task.photosRequired}
             >
-              <Ionicons name="checkmark-circle" size={20} color={task.photosSubmitted >= task.photosRequired ? 'white' : '#ff8c00'} />
+              <Ionicons
+                name={signatureUri ? 'checkmark-circle' : 'create-outline'}
+                size={20}
+                color={task.photosSubmitted >= task.photosRequired ? 'white' : '#ff8c00'}
+              />
               <Text style={task.photosSubmitted >= task.photosRequired ? styles.btnText : styles.btnOutlineText}>
-                {task.photosSubmitted >= task.photosRequired ? 'Complete Task' : `Need ${task.photosRequired - task.photosSubmitted} more photo(s)`}
+                {task.photosSubmitted < task.photosRequired
+                  ? `Need ${task.photosRequired - task.photosSubmitted} more photo(s)`
+                  : signatureUri
+                    ? 'Complete Task'
+                    : 'Sign & complete'}
               </Text>
             </TouchableOpacity>
         )}
@@ -1120,6 +1176,13 @@ export default function TicketDetailScreen() {
           </View>
         </View>
       </Modal>
+
+      <SignatureModal
+        visible={signatureModalOpen}
+        onCancel={() => setSignatureModalOpen(false)}
+        onConfirm={handleSignatureConfirmed}
+        signerName={ticketData?.assigned_contractor_name ?? undefined}
+      />
 
     </MainFrame>
   );


### PR DESCRIPTION
## Summary

Adds signature capture as a final gate on the Complete Task flow. Before submitting a ticket for approval, the contractor draws a signature on a full-screen pad. The PNG rides through the existing photo outbox so it inherits offline durability and retry without any new backend plumbing.

Closes the "proof of work" gap in the showcase story (real GPS, real photos, real biometric, now real signed sign-off).

## What's in this PR

### Frontend (`field-force-contractor/`)
- **New `components/SignatureModal.tsx`** — full-screen Modal wrapping `react-native-signature-canvas`. Custom dark header, white canvas, Clear + Save buttons. Suppresses the library's default footer with WebView CSS so the styling matches the rest of the app.
- **`screens/TicketDetailScreen.tsx`**
  - New state: `signatureModalOpen`, `signatureUri`.
  - `handleCompleteTask` now gates on `signatureUri`. If absent, opens the modal and bails. If present, calls `submitCompletion(sigUri)` which performs the PUT and uploads photos + signature.
  - `handleSignatureConfirmed(dataUrl)` strips the `data:image/png;base64,` prefix, writes the PNG to `documentDirectory/signature_<taskId>_<ts>.png` so the URI survives ImagePicker cache eviction, and re-enters `submitCompletion`.
  - Complete Task button label switches between "Sign & complete" and "Complete Task" based on whether a signature exists.
  - Signature is appended to the photo upload list so it's the last item the approver sees, but rides through the same `uploadPhotoOrEnqueue` path as the regular photos.
- **`package.json`** — adds `react-native-signature-canvas@^5.0.2` and its peer `react-native-webview@13.15.0` (Expo-recommended version).

## Backend

No backend changes. Signatures land in the existing `ticket_photo` table, keyed by `submission_uuid` and `content_hash` like every other photo. Filenames follow the pattern `signature_<taskId>_<ts>.png` so a follow-up PR can promote signatures to a dedicated column or `kind` enum without breaking what's shipped.

## Out of scope

- Signature gallery / re-display once uploaded. The signature is "fire and forget" proof; the approver sees it in the photo list.
- Backend column to flag a `ticket_photo` row as a signature. Filename pattern is enough for showcase; can promote post-launch.
- Re-signing (clearing the on-device cached signatureUri after a successful submit). The screen state resets on navigation, which is sufficient.

## Test plan

**Local typecheck:**
- [x] `npx tsc --noEmit` produces no new errors (5 pre-existing errors unchanged)

**Device (Expo Go iOS, on the demo phone):**
- [ ] Open an in-progress ticket with the photo requirement met
- [ ] Tap "Sign & complete" -> SignatureModal opens
- [ ] Drawing produces visible strokes; Clear wipes them
- [ ] Save with empty pad is a no-op (no crash)
- [ ] Save with a real signature closes modal, fires the PUT, queues the PNG
- [ ] Bounce to Tickets list; ticket shows in Pending Approval
- [ ] On the backend, a new ticket_photo row appears with `signature_<taskId>_*.png` content (and rides the offline outbox if disconnected when tapping Save)

**Edge cases:**
- [ ] Cancel from modal returns to TicketDetail without changing state
- [ ] Backgrounding / closing the app between Save and the upload still results in the signature reaching the backend (durability via documentDirectory + photoOutbox)
