### PR TITLE
fix(ux): no demo-contact flash + AI tab keyboard no longer pushes bottom menu

### DIFF
--- a/frontend/field-force-contractor/screens/ChatAssistantScreen.tsx
+++ b/frontend/field-force-contractor/screens/ChatAssistantScreen.tsx
@@ -9,9 +9,7 @@ import { FC, useEffect, useRef, useState } from 'react'
 import {
     Alert,
     Animated,
-    KeyboardAvoidingView,
     Modal,
-    Platform,
     ScrollView,
     Share,
     StyleSheet,
@@ -464,19 +462,24 @@ export const ChatAssistantScreen: FC = () => {
         }
     }
 
+    // SearchBar handles its own keyboard-aware float via the floatBox spacer
+    // (see SearchBar.tsx + Styles.Chat.floatBox). We pass keyboardAware so
+    // the spacer fires, and we render the SearchBar directly into the
+    // MainFrame footer slot instead of wrapping it in a KeyboardAvoidingView,
+    // which used to push the bottom menu up alongside the SearchBar. Jonathan
+    // flagged this during testing — the previous wrapping caused the menu
+    // and spacer to float when the keyboard appeared.
     const Footer: FC = () => (
         <SearchBar
             placeHolder="Ask the assistant..."
             buttonText="Send"
             onClick={(msg: string) => { if (msg) send(msg) }}
+            keyboardAware={true}
         />
     )
 
     return (
-        <KeyboardAvoidingView
-            style={{ flex: 1 }}
-            behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        >
+        <>
             <MainFrame
                 headerMenu={['Menu2', ['Field Assistant']]}
                 injectFooter={<Footer />}
@@ -711,7 +714,7 @@ export const ChatAssistantScreen: FC = () => {
                     </View>
                 </Modal>
             </MainFrame>
-        </KeyboardAvoidingView>
+        </>
     )
 }
 

--- a/frontend/field-force-contractor/screens/ContactScreen.tsx
+++ b/frontend/field-force-contractor/screens/ContactScreen.tsx
@@ -2,6 +2,7 @@ import { RootStackParamList } from "@/App"
 import { ContactCard } from "@/components/ContactCard"
 import { MainFrame } from "@/components/MainFrame"
 import { SearchBar } from "@/components/SearchBar"
+import { SHOWCASE_MODE } from "@/constants/showcase"
 import { AppContext, demoUsers, userTable } from "@/contexts/AppContext"
 import { api } from "@/utils/api"
 import { RouteProp, useNavigation, useRoute } from "@react-navigation/native"
@@ -32,14 +33,20 @@ const toUserRow = (c: BackendContact): userTable => ({
 export const Contacts:FC = (props) => {
     const nav = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
     const {client} = useContext(AppContext)
-    const [remoteContacts, setRemoteContacts] = useState<userTable[] | null>(null)
+    // Start empty (not with demoUsers) so the screen never flashes demo
+    // contacts before the real backend list arrives. Jonathan caught this
+    // during testing — the previous `useState<...>(null)` fell back to
+    // demoUsers on first render which is visible as a brief glitch.
+    const [remoteContacts, setRemoteContacts] = useState<userTable[]>([])
+    const [loadFailed, setLoadFailed] = useState(false)
     const [nameSearch, setNameSearch] = useState("")
     const route = useRoute<RouteProp<RootStackParamList,'Contacts'>>()
     const sort = route.params?.sort
 
-    // Pull the real contact list from the backend. Falls back to demoUsers
-    // if the request fails so the screen is still usable offline / when the
-    // backend is unreachable.
+    // Pull the real contact list from the backend. Only fall back to
+    // demoUsers when (a) the fetch genuinely failed AND (b) we're in
+    // SHOWCASE_MODE, so demo builds stay functional offline while
+    // production never shows fake demo data.
     useEffect(() => {
         let cancelled = false;
         (async () => {
@@ -48,17 +55,24 @@ export const Contacts:FC = (props) => {
                 if (cancelled) return
                 const rows = (res?.contacts ?? []).map(toUserRow)
                 setRemoteContacts(rows)
+                setLoadFailed(false)
             } catch {
-                if (!cancelled) setRemoteContacts(null)
+                if (!cancelled) setLoadFailed(true)
             }
         })()
         return () => { cancelled = true }
     }, [])
 
-    // Prefer the real backend list when we have it. Append the current
-    // client object so the sort=true filter still works the way it did on
-    // the demo data.
-    const base: userTable[] = remoteContacts ?? demoUsers
+    // Real backend list wins. If the fetch failed AND we're in showcase
+    // mode, fall back to demoUsers so the demo doesn't break offline.
+    // Production with a backend failure shows an empty list rather than
+    // fake data.
+    const base: userTable[] =
+        remoteContacts.length > 0
+            ? remoteContacts
+            : (loadFailed && SHOWCASE_MODE)
+                ? demoUsers
+                : []
     const contacts: userTable[] = (client) ? [...base, client] : base
 
     const Search:FC = () => (


### PR DESCRIPTION
Small flow fixes from Jonathan's run-through of the integrated branch.

## What this changes

**1. ContactScreen demo-contact flash on first render**

`remoteContacts` previously initialised to `null`, which made the render fall back to `demoUsers` for the brief window between mount and the `/contractors/contacts` response. Jonathan saw the placeholder John Doe / Jane Doe / etc. contacts flash before the real Supabase rows came in.

- Initialise `remoteContacts` to `[]` (no flash).
- Track `loadFailed` separately.
- Only fall back to `demoUsers` when the fetch genuinely failed AND `SHOWCASE_MODE` is on. Demo builds stay usable if the backend hiccups, production builds never show fake demo data on a network failure (empty list instead).

**2. AI tab keyboard pushes the bottom menu + spacer**

`ChatAssistantScreen` wrapped `MainFrame` in `KeyboardAvoidingView` with `behavior='padding'/'height'`, which shoves the entire layout (including the bottom menu and the SearchBar's own `floatBox` spacer) up when the keyboard appears. The SearchBar also did not have `keyboardAware={true}`, so its own float-above-keyboard behavior never fired.

- Drop the `KeyboardAvoidingView` wrapper.
- Render the SearchBar directly into `MainFrame`'s `injectFooter` slot with `keyboardAware={true}`.
- SearchBar's existing `floatBox` + listener (now correctly bound to `menuHeight` via PR #250) handles the keyboard offset without disturbing the bottom menu.

Removed unused `KeyboardAvoidingView` + `Platform` imports while in there.

## Test plan

- [ ] Open Contacts screen, scroll fast on mount, no John Doe flash before real names appear.
- [ ] Open AI tab (`Field Assistant`), tap the input, keyboard slides up, SearchBar floats just above the keyboard, bottom menu stays put.
- [ ] Send a message, keyboard closes, layout returns to default.
- [ ] Toggle `SHOWCASE_MODE = false` locally + kill network → Contacts screen shows empty list (not `demoUsers`).